### PR TITLE
Avdekke JobCancellationException

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/services/ClientCallWrapper.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/ClientCallWrapper.kt
@@ -10,12 +10,17 @@ import no.nav.medlemskap.common.clientTimer
 private val logger = KotlinLogging.logger { }
 
 suspend fun <T> runWithRetryAndMetrics(service: String, operation: String, retry: Retry?, block: suspend () -> T): T {
-    retry?.let {
-        return it.executeSuspendFunction {
-            runWithMetrics(service, operation, block)
+    try {
+        retry?.let {
+            return it.executeSuspendFunction {
+                runWithMetrics(service, operation, block)
+            }
         }
+        return runWithMetrics(service, operation, block)
+    } catch (t: Throwable) {
+        logger.warn("Feilet under kall mot $service:$operation", t)
+        throw t
     }
-    return runWithMetrics(service, operation, block)
 }
 
 suspend fun <T> runWithMetrics(service: String, operation: String, block: suspend () -> T): T {

--- a/src/test/kotlin/no/nav/medlemskap/services/aareg/AaregClientRetryTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/services/aareg/AaregClientRetryTest.kt
@@ -1,0 +1,39 @@
+package no.nav.medlemskap.services.aareg
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import no.nav.medlemskap.config.retryRegistry
+import no.nav.medlemskap.services.sts.StsRestClient
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+
+class AaregClientRetryTest {
+
+    private val testRetry = retryRegistry.retry("AaReg")
+
+    @Test()
+    fun `JobCancellationException kastes naar backend service ikke naas`() {
+        //Ref https://github.com/ktorio/ktor/issues/1592
+        val callId: () -> String = { "12345" }
+
+        val stsClient: StsRestClient = mockk()
+        coEvery { stsClient.oidcToken() } returns "dummytoken"
+
+        val client = spyk(AaRegClient("http://localhost:9987/finnesIkke", stsClient, callId, testRetry))
+
+        assertThrows<CancellationException> {
+            runBlocking { client.hentArbeidsforhold("26104635775", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+        }
+
+        coVerify(exactly = 2) { client.hentArbeidsforhold(any(), any(), any()) }
+    }
+}
+
+
+


### PR DESCRIPTION
Lagt til en test for å dokumentere hvordan JobCancellationException kan oppstå, og lagt til logging rundt klient-kall for å avdekke om hypotesen er korrekt i praksis.. 