### PR TITLE
Sender nå rundt callId

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/HttpServer.kt
+++ b/src/main/kotlin/no/nav/medlemskap/HttpServer.kt
@@ -10,9 +10,12 @@ import io.ktor.routing.routing
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import no.nav.medlemskap.common.*
+import no.nav.medlemskap.common.JwtConfig
 import no.nav.medlemskap.common.JwtConfig.Companion.REALM
+import no.nav.medlemskap.common.MDC_CALL_ID
+import no.nav.medlemskap.common.exceptionHandler
 import no.nav.medlemskap.common.healthcheck.healthRoute
+import no.nav.medlemskap.common.objectMapper
 import no.nav.medlemskap.config.AzureAdOpenIdConfiguration
 import no.nav.medlemskap.config.Configuration
 import no.nav.medlemskap.config.getAadConfig
@@ -20,8 +23,8 @@ import no.nav.medlemskap.routes.evalueringRoute
 import no.nav.medlemskap.routes.naisRoutes
 import no.nav.medlemskap.routes.reglerRoute
 import no.nav.medlemskap.services.Services
-
 import org.slf4j.event.Level
+import java.util.*
 
 fun createHttpServer(
         applicationState: ApplicationState,
@@ -46,8 +49,8 @@ fun createHttpServer(
 
     install(CallId) {
         header(MDC_CALL_ID)
-        generate { callIdGenerator.get() }
-        reply { _, callId -> callIdGenerator.set(callId) }
+        generate { UUID.randomUUID().toString() }
+        verify { callId: String -> callId.isNotEmpty() }
     }
 
     if (useAuthentication) {

--- a/src/main/kotlin/no/nav/medlemskap/services/RestClients.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/RestClients.kt
@@ -1,6 +1,7 @@
 package no.nav.medlemskap.services
 
-import no.nav.medlemskap.config.*
+import no.nav.medlemskap.config.Configuration
+import no.nav.medlemskap.config.retryRegistry
 import no.nav.medlemskap.services.aareg.AaRegClient
 import no.nav.medlemskap.services.inntekt.InntektClient
 import no.nav.medlemskap.services.medl.MedlClient
@@ -10,7 +11,6 @@ import no.nav.medlemskap.services.saf.SafClient
 import no.nav.medlemskap.services.sts.StsRestClient
 
 class RestClients(private val stsClientRest: StsRestClient,
-                  private val callIdGenerator: () -> String,
                   private val configuration: Configuration) {
 
     private val aaRegRetry = retryRegistry.retry("AaReg")
@@ -20,11 +20,11 @@ class RestClients(private val stsClientRest: StsRestClient,
     private val pdlRetry = retryRegistry.retry("PDL")
     private val safRetry = retryRegistry.retry("Saf")
 
-    fun aaReg(endpointUrl: String) = AaRegClient(endpointUrl, stsClientRest, callIdGenerator, aaRegRetry)
-    fun medl2(endpointBaseUrl: String) = MedlClient(endpointBaseUrl, stsClientRest, callIdGenerator, configuration, medlRetry)
-    fun inntektskomponenten(endpointBaseUrl: String) = InntektClient(endpointBaseUrl, stsClientRest, callIdGenerator, configuration, inntektRetry)
-    fun saf(endpointBaseUrl: String) = SafClient(endpointBaseUrl, stsClientRest, callIdGenerator, configuration, safRetry)
-    fun oppgaver(endpointBaseUrl: String) = OppgaveClient(endpointBaseUrl, stsClientRest, callIdGenerator, oppgaveRetry)
-    fun pdl(endpointBaseURl: String) = PdlClient(endpointBaseURl, stsClientRest, callIdGenerator, configuration, pdlRetry)
+    fun aaReg(endpointUrl: String) = AaRegClient(endpointUrl, stsClientRest, aaRegRetry)
+    fun medl2(endpointBaseUrl: String) = MedlClient(endpointBaseUrl, stsClientRest, configuration, medlRetry)
+    fun inntektskomponenten(endpointBaseUrl: String) = InntektClient(endpointBaseUrl, stsClientRest, configuration, inntektRetry)
+    fun saf(endpointBaseUrl: String) = SafClient(endpointBaseUrl, stsClientRest, configuration, safRetry)
+    fun oppgaver(endpointBaseUrl: String) = OppgaveClient(endpointBaseUrl, stsClientRest, oppgaveRetry)
+    fun pdl(endpointBaseURl: String) = PdlClient(endpointBaseURl, stsClientRest, configuration, pdlRetry)
 
 }

--- a/src/main/kotlin/no/nav/medlemskap/services/Services.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/Services.kt
@@ -69,7 +69,6 @@ class Services(val configuration: Configuration) {
 
         val restClients = RestClients(
                 stsClientRest = stsRestClient,
-                callIdGenerator = callIdGenerator::get,
                 configuration = configuration
         )
 

--- a/src/main/kotlin/no/nav/medlemskap/services/inntekt/InntektClient.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/inntekt/InntektClient.kt
@@ -19,12 +19,11 @@ import java.time.format.DateTimeFormatter
 class InntektClient(
         private val baseUrl: String,
         private val stsClient: StsRestClient,
-        private val callIdGenerator: () -> String,
         private val configuration: Configuration,
         private val retry: Retry? = null
 ) {
 
-    suspend fun hentInntektListe(ident: String, fraOgMed: LocalDate? = null, tilOgMed: LocalDate? = null): InntektskomponentResponse {
+    suspend fun hentInntektListe(ident: String, callId: String, fraOgMed: LocalDate? = null, tilOgMed: LocalDate? = null): InntektskomponentResponse {
         val token = stsClient.oidcToken()
         return runCatching {
             runWithRetryAndMetrics("Inntekt", "HentinntektlisteV1", retry) {
@@ -33,7 +32,7 @@ class InntektClient(
                     header(HttpHeaders.Authorization, "Bearer $token")
                     header(HttpHeaders.ContentType, ContentType.Application.Json)
                     header("Nav-Consumer-Id", configuration.sts.username)
-                    header("Nav-Call-Id", callIdGenerator.invoke())
+                    header("Nav-Call-Id", callId)
                     body = HentInntektListeRequest(
                             ident = Ident(ident, "NATURLIG_IDENT"),
                             ainntektsfilter = "MedlemskapA-inntekt",
@@ -73,8 +72,8 @@ class InntektClient(
 
 class InntektService(private val inntektClient: InntektClient) {
 
-    suspend fun hentInntektListe(ident: String, fraOgMed: LocalDate?, tilOgMed: LocalDate?) =
-            mapInntektResultat(inntektClient.hentInntektListe(ident, fraOgMed, tilOgMed))
+    suspend fun hentInntektListe(ident: String, callId: String, fraOgMed: LocalDate?, tilOgMed: LocalDate?) =
+            mapInntektResultat(inntektClient.hentInntektListe(ident, callId, fraOgMed, tilOgMed))
 
 }
 

--- a/src/main/kotlin/no/nav/medlemskap/services/medl/MedlClient.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/medl/MedlClient.kt
@@ -19,12 +19,11 @@ import java.time.format.DateTimeFormatter
 class MedlClient(
         private val baseUrl: String,
         private val stsClient: StsRestClient,
-        private val callIdGenerator: () -> String,
         private val configuration: Configuration,
         private val retry: Retry? = null
 ) {
 
-    suspend fun hentMedlemskapsunntak(ident: String, fraOgMed: LocalDate? = null, tilOgMed: LocalDate? = null): List<MedlMedlemskapsunntak> {
+    suspend fun hentMedlemskapsunntak(ident: String, callId: String, fraOgMed: LocalDate? = null, tilOgMed: LocalDate? = null): List<MedlMedlemskapsunntak> {
         val token = stsClient.oidcToken()
         return runCatching {
             runWithRetryAndMetrics("Medl", "MedlemskapsunntakV1", retry) {
@@ -32,7 +31,7 @@ class MedlClient(
                     url("$baseUrl/api/v1/medlemskapsunntak")
                     header(HttpHeaders.Authorization, "Bearer $token")
                     header(HttpHeaders.Accept, ContentType.Application.Json)
-                    header("Nav-Call-Id", callIdGenerator.invoke())
+                    header("Nav-Call-Id", callId)
                     header("Nav-Personident", ident)
                     header("Nav-Consumer-Id", configuration.sts.username)
                     fraOgMed?.let { parameter("fraOgMed", fraOgMed.tilIsoFormat()) }
@@ -70,6 +69,6 @@ class MedlClient(
 
 class MedlService(private val medlClient: MedlClient) {
 
-    suspend fun hentMedlemskapsunntak(ident: String, fraOgMed: LocalDate? = null, tilOgMed: LocalDate? = null) =
-            mapMedlemskapResultat(medlClient.hentMedlemskapsunntak(ident, fraOgMed, tilOgMed))
+    suspend fun hentMedlemskapsunntak(ident: String, callId: String, fraOgMed: LocalDate? = null, tilOgMed: LocalDate? = null) =
+            mapMedlemskapResultat(medlClient.hentMedlemskapsunntak(ident, callId, fraOgMed, tilOgMed))
 }

--- a/src/test/kotlin/no/nav/medlemskap/services/aareg/AaregClientRetryTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/services/aareg/AaregClientRetryTest.kt
@@ -17,21 +17,21 @@ class AaregClientRetryTest {
 
     private val testRetry = retryRegistry.retry("AaReg")
 
-    @Test()
+    @Test
     fun `JobCancellationException kastes naar backend service ikke naas`() {
         //Ref https://github.com/ktorio/ktor/issues/1592
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
 
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
-        val client = spyk(AaRegClient("http://localhost:9987/finnesIkke", stsClient, callId, testRetry))
+        val client = spyk(AaRegClient("http://localhost:9987/finnesIkke", stsClient, testRetry))
 
         assertThrows<CancellationException> {
-            runBlocking { client.hentArbeidsforhold("26104635775", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+            runBlocking { client.hentArbeidsforhold("26104635775", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
         }
 
-        coVerify(exactly = 2) { client.hentArbeidsforhold(any(), any(), any()) }
+        coVerify(exactly = 2) { client.hentArbeidsforhold(any(), any(), any(), any()) }
     }
 }
 

--- a/src/test/kotlin/no/nav/medlemskap/services/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/services/aareg/AaregClientTest.kt
@@ -42,7 +42,7 @@ class AaregClientTest {
 
     @Test
     fun `tester response`() {
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
 
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
@@ -54,9 +54,9 @@ class AaregClientTest {
                         .withBody(aaRegResponse)
         ))
 
-        val client = AaRegClient(server.baseUrl(), stsClient, callId)
+        val client = AaRegClient(server.baseUrl(), stsClient)
 
-        val response = runBlocking { client.hentArbeidsforhold("26104635775", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+        val response = runBlocking { client.hentArbeidsforhold("26104635775", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
         println(response)
 
 
@@ -68,9 +68,7 @@ class AaregClientTest {
 
     @Test
     fun `tester ServerResponseException`() {
-
-
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -80,17 +78,16 @@ class AaregClientTest {
                         .withHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
 
         ))
-        val client = AaRegClient(server.baseUrl(), stsClient, callId)
+        val client = AaRegClient(server.baseUrl(), stsClient)
 
         Assertions.assertThrows(ServerResponseException::class.java) {
-            runBlocking { client.hentArbeidsforhold("26104635775", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+            runBlocking { client.hentArbeidsforhold("26104635775", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
         }
     }
 
     @Test
     fun `tester ClientRequestException`() {
-
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -101,16 +98,16 @@ class AaregClientTest {
 
         ))
 
-        val client = AaRegClient(server.baseUrl(), stsClient, callId)
+        val client = AaRegClient(server.baseUrl(), stsClient)
 
         Assertions.assertThrows(ClientRequestException::class.java) {
-            runBlocking { client.hentArbeidsforhold("26104635775", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+            runBlocking { client.hentArbeidsforhold("26104635775", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
         }
     }
 
     @Test
     fun `404 gir tom liste`() {
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -121,8 +118,8 @@ class AaregClientTest {
 
         ))
 
-        val client = AaRegClient(server.baseUrl(), stsClient, callId)
-        val response = runBlocking { client.hentArbeidsforhold("26104635775", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+        val client = AaRegClient(server.baseUrl(), stsClient)
+        val response = runBlocking { client.hentArbeidsforhold("26104635775", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
 
         Assertions.assertEquals(0, response.size)
     }

--- a/src/test/kotlin/no/nav/medlemskap/services/inntekt/InntektClientTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/services/inntekt/InntektClientTest.kt
@@ -14,8 +14,6 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.medlemskap.config.Configuration
-import no.nav.medlemskap.services.aareg.AaRegClient
-import no.nav.medlemskap.services.aareg.AaregClientTest
 import no.nav.medlemskap.services.sts.StsRestClient
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -47,7 +45,7 @@ class InntektClientTest {
 
     @Test
     fun `tester response`() {
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
 
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
@@ -59,9 +57,9 @@ class InntektClientTest {
                         .withBody(inntektResponse)
         ))
 
-        val client = InntektClient(server.baseUrl(), stsClient, callId, config)
+        val client = InntektClient(server.baseUrl(), stsClient, config)
 
-        val response = runBlocking { client.hentInntektListe("10108000398", LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
+        val response = runBlocking { client.hentInntektListe("10108000398", callId, LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
         println(response)
 
         assertEquals(YearMonth.of(2016, 1), response.arbeidsInntektMaaned?.get(0)?.aarMaaned)
@@ -75,7 +73,7 @@ class InntektClientTest {
     fun `tester ServerResponseException`() {
 
 
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -85,17 +83,16 @@ class InntektClientTest {
                         .withHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
 
         ))
-        val client = InntektClient(server.baseUrl(), stsClient, callId, config)
+        val client = InntektClient(server.baseUrl(), stsClient, config)
 
         Assertions.assertThrows(ServerResponseException::class.java) {
-            runBlocking { client.hentInntektListe("10108000398", LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
+            runBlocking { client.hentInntektListe("10108000398", callId, LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
         }
     }
 
     @Test
     fun `tester ClientRequestException`() {
-
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -106,10 +103,10 @@ class InntektClientTest {
 
         ))
 
-        val client = InntektClient(server.baseUrl(), stsClient, callId, config)
+        val client = InntektClient(server.baseUrl(), stsClient, config)
 
         Assertions.assertThrows(ClientRequestException::class.java) {
-            runBlocking { client.hentInntektListe("10108000398", LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
+            runBlocking { client.hentInntektListe("10108000398", callId, LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
         }
 
     }

--- a/src/test/kotlin/no/nav/medlemskap/services/inntekt/InntektClientTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/services/inntekt/InntektClientTest.kt
@@ -73,8 +73,6 @@ class InntektClientTest {
 
     @Test
     fun `tester ServerResponseException`() {
-
-
         val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
@@ -91,7 +89,7 @@ class InntektClientTest {
 ////            runBlocking { client.hentInntektListe("10108000398", callId, LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
 ////        }
 
-        val response = runBlocking { client.hentInntektListe("10108000398", LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
+        val response = runBlocking { client.hentInntektListe("10108000398", callId, LocalDate.of(2016, 1, 1), LocalDate.of(2016, 8, 1)) }
         assertThat(response.arbeidsInntektMaaned).isNotNull()
         assertThat(response.arbeidsInntektMaaned!!.size).isEqualTo(0)
     }

--- a/src/test/kotlin/no/nav/medlemskap/services/medl/medlClientTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/services/medl/medlClientTest.kt
@@ -46,7 +46,7 @@ class medlClientTest {
 
     @Test
     fun `tester response 200 OK`() {
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -57,17 +57,15 @@ class medlClientTest {
                         .withBody(medlResponse)
         ))
 
-        val client = MedlClient(server.baseUrl(), stsClient, callId, config)
-        val response = runBlocking { client.hentMedlemskapsunntak("10109000398", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+        val client = MedlClient(server.baseUrl(), stsClient, config)
+        val response = runBlocking { client.hentMedlemskapsunntak("10109000398", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
 
         Assertions.assertEquals("Full", response[0].dekning)
     }
 
     @Test
     fun `tester ServerResponseException`() {
-
-
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -78,17 +76,17 @@ class medlClientTest {
 
         ))
 
-        val client = MedlClient(server.baseUrl(), stsClient, callId, config)
+        val client = MedlClient(server.baseUrl(), stsClient, config)
 
         Assertions.assertThrows(ServerResponseException::class.java) {
-            runBlocking { client.hentMedlemskapsunntak("10109000398", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+            runBlocking { client.hentMedlemskapsunntak("10109000398", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
         }
     }
 
     @Test
     fun `tester ClientRequestException`() {
 
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -99,16 +97,16 @@ class medlClientTest {
 
         ))
 
-        val client = MedlClient(server.baseUrl(), stsClient, callId, config)
+        val client = MedlClient(server.baseUrl(), stsClient, config)
 
         Assertions.assertThrows(ClientRequestException::class.java) {
-            runBlocking { client.hentMedlemskapsunntak("10109000398", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+            runBlocking { client.hentMedlemskapsunntak("10109000398", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
         }
     }
 
     @Test
     fun `404 gir tom liste`() {
-        val callId: () -> String = { "12345" }
+        val callId = "12345"
         val stsClient: StsRestClient = mockk()
         coEvery { stsClient.oidcToken() } returns "dummytoken"
 
@@ -119,8 +117,8 @@ class medlClientTest {
 
         ))
 
-        val client = MedlClient(server.baseUrl(), stsClient, callId, config)
-        val response = runBlocking { client.hentMedlemskapsunntak("10109000398", LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
+        val client = MedlClient(server.baseUrl(), stsClient, config)
+        val response = runBlocking { client.hentMedlemskapsunntak("10109000398", callId, LocalDate.of(2010, 1, 1), LocalDate.of(2016, 1, 1)) }
 
         Assertions.assertEquals(0, response.size)
     }


### PR DESCRIPTION
Gjør ikke noe med TPS-soap kallet, siden dette snart forsvinner. Det kan bli en del styr med SOAP-interceptor. Så vil helst ikke gjøre det.