### PR TITLE
Lagt inn Micrometer-støtte for å håndtere basis-metrikkene våre

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ repositories {
 }
 
 
+
 dependencies {
     implementation(kotlin("stdlib"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
@@ -60,6 +61,8 @@ dependencies {
     implementation("io.ktor:ktor-client-json:$ktorVersion")
     implementation("io.ktor:ktor-client-jackson:$ktorVersion")
     implementation("io.ktor:ktor-jackson:$ktorVersion")
+    implementation("io.ktor:ktor-metrics-micrometer:$ktorVersion")
+    implementation("io.micrometer:micrometer-registry-prometheus:latest.release")
     implementation("io.prometheus:simpleclient_hotspot:$prometheusVersion")
     implementation("io.prometheus:simpleclient_common:$prometheusVersion")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")

--- a/src/main/kotlin/no/nav/medlemskap/Application.kt
+++ b/src/main/kotlin/no/nav/medlemskap/Application.kt
@@ -1,12 +1,19 @@
 package no.nav.medlemskap
 
-import java.util.concurrent.TimeUnit
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import io.micrometer.prometheus.PrometheusRenameFilter
 
 data class ApplicationState(var running: Boolean = true, var initialized: Boolean = false)
 
+val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
 fun main() {
     val applicationState = ApplicationState()
-    val applicationServer = createHttpServer(applicationState)
+
+    prometheusRegistry.config().meterFilter(PrometheusRenameFilter())
+
+    val applicationServer = createHttpServer(applicationState = applicationState, prometheusRegistry = prometheusRegistry)
 
     Runtime.getRuntime().addShutdownHook(Thread {
         applicationState.initialized = false


### PR DESCRIPTION
I første omgang har jeg ikke endret bruken vår av Counters og Histograms og sånt, der bruker jeg bare Prometheus som før. Så hvorfor bruke Micrometer og ikke bare standard Prometheus? Jeg ser at en del rammeverk og biblioteker bruker Micrometer, så jeg tenker det er fint å ha støtte for det. 
Ktor støtter Micrometer, ref https://ktor.io/servers/features/metrics-micrometer.html
Recilience4j støtter Micrometer, ref https://resilience4j.readme.io/docs/micrometer

Ideen her er at 
prometheusRegistry.config().meterFilter(PrometheusRenameFilter())
skal gjøre så Micrometer skal rapportere de samme metrikkene som vanlig Prometheus, så vi skal ikke merke noen forskjell..