### PR TITLE
Added a new MeterRegistry that sends metrics to Influx by way of Sensu

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,39 @@
+Multiple libraries used in this software is licensed under the Apache 2.0 license and / or LGPL license
+
+Copyright (c) 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (C) 2019
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------------
+
+This program contains a modified portion of 'io.micrometer.influx',
+in the micrometer-registry-influx library distributed by the Micrometer Project:
+
+  * Copyright (c) 2017-Present Pivotal Software, Inc.
+  * License: Apache License v2.0
+  * Homepage: http://micrometer.io
+  * Code: https://github.com/micrometer-metrics/micrometer/tree/master/implementations/micrometer-registry-influx

--- a/src/main/kotlin/no/nav/medlemskap/Application.kt
+++ b/src/main/kotlin/no/nav/medlemskap/Application.kt
@@ -1,6 +1,7 @@
 package no.nav.medlemskap
 
 import no.nav.medlemskap.common.configurePrometheusMeterRegistry
+import no.nav.medlemskap.common.configureSensuInfluxMeterRegistry
 
 data class ApplicationState(var running: Boolean = true, var initialized: Boolean = false)
 
@@ -8,7 +9,7 @@ fun main() {
     val applicationState = ApplicationState()
 
     val prometheusMeterRegistry = configurePrometheusMeterRegistry()
-    //configureInfluxMeterRegistry()
+    configureSensuInfluxMeterRegistry()
 
     val applicationServer = createHttpServer(applicationState = applicationState, prometheusRegistry = prometheusMeterRegistry)
 

--- a/src/main/kotlin/no/nav/medlemskap/common/influx/ORIGINAL_MICROMETER_LICENSE
+++ b/src/main/kotlin/no/nav/medlemskap/common/influx/ORIGINAL_MICROMETER_LICENSE
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/main/kotlin/no/nav/medlemskap/common/influx/SensuInfluxConfig.java
+++ b/src/main/kotlin/no/nav/medlemskap/common/influx/SensuInfluxConfig.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2019 NAV
+ * <p>
+ * MIT License
+ * <p>
+ * This file incorporates works covered by the following copyright and permission notice:
+ * ---
+ * <p>
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.nav.medlemskap.common.influx;
+
+import io.micrometer.core.instrument.step.StepRegistryConfig;
+
+/**
+ * Configuration for {@link SensuInfluxMeterRegistry}.
+ * Modified from {@link io.micrometer.influx.InfluxConfig}.
+ *
+ * @see <a href="https://github.com/micrometer-metrics/micrometer/tree/v1.3.5/implementations/micrometer-registry-influx">https://github.com/micrometer-metrics/micrometer/tree/v1.3.5/implementations/micrometer-registry-influx</a>
+ */
+public interface SensuInfluxConfig extends StepRegistryConfig {
+    /**
+     * Accept configuration defaults
+     */
+    SensuInfluxConfig DEFAULT = k -> null;
+
+    @Override
+    default String prefix() {
+        return "sensuinflux";
+    }
+
+    /**
+     * @return The db to send metrics to. Defaults to "default".
+     */
+    default String db() {
+        return "default";
+    }
+
+    /**
+     * @return The hostname for the Sensu backend. The default is {@code sensu.nais}.
+     */
+    default String hostname() {
+        return "sensu.nais";
+    }
+
+    /**
+     * @return The port for the Sensu backend. The default is {@code 3030}.
+     */
+    default Integer port() {
+        return 3030;
+    }
+
+    /**
+     * @return The name of the metrics for the Sensu backend. Default is "test-events", but should be overriden.
+     */
+    default String sensuName() {
+        return "test-events";
+    }
+}

--- a/src/main/kotlin/no/nav/medlemskap/common/influx/SensuInfluxMeterRegistry.java
+++ b/src/main/kotlin/no/nav/medlemskap/common/influx/SensuInfluxMeterRegistry.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2019 NAV
+ * <p>
+ * MIT License
+ * <p>
+ * This file incorporates works covered by the following copyright and permission notice:
+ * ---
+ * <p>
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.nav.medlemskap.common.influx;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.core.instrument.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * MeterRegistry for Influx by way of Sensu
+ * Modified from {@link io.micrometer.influx.InfluxMeterRegistry}.
+ *
+ * @see <a href="https://github.com/micrometer-metrics/micrometer/tree/v1.3.5/implementations/micrometer-registry-influx">https://github.com/micrometer-metrics/micrometer/tree/v1.3.5/implementations/micrometer-registry-influx</a>
+ */
+public class SensuInfluxMeterRegistry extends StepMeterRegistry {
+    private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("sensu-influx-metrics-publisher");
+    private final SensuInfluxConfig config;
+    private final Logger logger = LoggerFactory.getLogger(SensuInfluxMeterRegistry.class);
+
+    public SensuInfluxMeterRegistry(SensuInfluxConfig config, Clock clock) {
+        this(config, clock, DEFAULT_THREAD_FACTORY);
+    }
+
+    private SensuInfluxMeterRegistry(SensuInfluxConfig config, Clock clock, ThreadFactory threadFactory) {
+        super(config, clock);
+        config().namingConvention(new SensuInfluxNamingConvention());
+        this.config = config;
+        start(threadFactory);
+    }
+
+    public static Builder builder(SensuInfluxConfig config) {
+        return new Builder(config);
+    }
+
+    @Override
+    public void start(ThreadFactory threadFactory) {
+        if (config.enabled()) {
+            logger.info("publishing metrics to influx every " + TimeUtils.format(config.step()));
+        }
+        super.start(threadFactory);
+    }
+
+    @Override
+    protected void publish() {
+        try {
+            String hostname = config.hostname();
+            int port = config.port();
+            String sensuName = config.sensuName();
+
+            for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
+
+                String influxLineProtocolData = batch.stream()
+                        .flatMap(m -> m.match(
+                                gauge -> writeGauge(gauge.getId(), gauge.value()),
+                                counter -> writeCounter(counter.getId(), counter.count()),
+                                this::writeTimer,
+                                this::writeSummary,
+                                this::writeLongTaskTimer,
+                                gauge -> writeGauge(gauge.getId(), gauge.value(getBaseTimeUnit())),
+                                counter -> writeCounter(counter.getId(), counter.count()),
+                                this::writeFunctionTimer,
+                                this::writeMeter))
+                        .collect(joining("\n"));
+                SensuEvent data = new SensuEvent(sensuName, influxLineProtocolData);
+
+                long startTime = System.currentTimeMillis();
+                try (Socket socket = new Socket(hostname, port)) {
+
+                    try (OutputStreamWriter writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8)) {
+                        writer.write(data.getJson(), 0, data.getJson().length());
+                        writer.flush();
+                        logger.debug("wrote {} bytes of data", data.getJson().length());
+                    } catch (IOException e) {
+                        logger.error("Unable to send event {}", data, e);
+                    }
+
+                } catch (UnknownHostException e) {
+                    logger.error("Unknown host: {}:{} {}", hostname, port, e.getMessage());
+                } catch (IOException e) {
+                    logger.error("Unable to send event to {}:{}", hostname, port, e);
+                } catch (Exception e) {
+                    logger.error("Unable to send event", e);
+                } finally {
+                    logger.info("Influx/sensu reporting time: {}", System.currentTimeMillis() - startTime);
+                }
+            }
+        } catch (Throwable e) {
+            logger.error("failed to send metrics to influx", e);
+        }
+    }
+
+    // VisibleForTesting
+    Stream<String> writeMeter(Meter m) {
+        List<Field> fields = new ArrayList<>();
+        for (Measurement measurement : m.measure()) {
+            double value = measurement.getValue();
+            if (!Double.isFinite(value)) {
+                continue;
+            }
+            String fieldKey = measurement.getStatistic().getTagValueRepresentation()
+                    .replaceAll("(.)(\\p{Upper})", "$1_$2").toLowerCase();
+            fields.add(new Field(fieldKey, value));
+        }
+        if (fields.isEmpty()) {
+            return Stream.empty();
+        }
+        Meter.Id id = m.getId();
+        return Stream.of(influxLineProtocol(id, id.getType().name().toLowerCase(), fields.stream()));
+    }
+
+    private Stream<String> writeLongTaskTimer(LongTaskTimer timer) {
+        Stream<Field> fields = Stream.of(
+                new Field("active_tasks", timer.activeTasks()),
+                new Field("duration", timer.duration(getBaseTimeUnit()))
+        );
+        return Stream.of(influxLineProtocol(timer.getId(), "long_task_timer", fields));
+    }
+
+    // VisibleForTesting
+    Stream<String> writeCounter(Meter.Id id, double count) {
+        if (Double.isFinite(count)) {
+            return Stream.of(influxLineProtocol(id, "counter", Stream.of(new Field("value", count))));
+        }
+        return Stream.empty();
+    }
+
+    // VisibleForTesting
+    Stream<String> writeGauge(Meter.Id id, Double value) {
+        if (Double.isFinite(value)) {
+            return Stream.of(influxLineProtocol(id, "gauge", Stream.of(new Field("value", value))));
+        }
+        return Stream.empty();
+    }
+
+    private Stream<String> writeFunctionTimer(FunctionTimer timer) {
+        Stream<Field> fields = Stream.of(
+                new Field("sum", timer.totalTime(getBaseTimeUnit())),
+                new Field("count", timer.count()),
+                new Field("mean", timer.mean(getBaseTimeUnit()))
+        );
+
+        return Stream.of(influxLineProtocol(timer.getId(), "histogram", fields));
+    }
+
+    private Stream<String> writeTimer(Timer timer) {
+        final Stream<Field> fields = Stream.of(
+                new Field("sum", timer.totalTime(getBaseTimeUnit())),
+                new Field("count", timer.count()),
+                new Field("mean", timer.mean(getBaseTimeUnit())),
+                new Field("upper", timer.max(getBaseTimeUnit()))
+        );
+
+        return Stream.of(influxLineProtocol(timer.getId(), "histogram", fields));
+    }
+
+    private Stream<String> writeSummary(DistributionSummary summary) {
+        final Stream<Field> fields = Stream.of(
+                new Field("sum", summary.totalAmount()),
+                new Field("count", summary.count()),
+                new Field("mean", summary.mean()),
+                new Field("upper", summary.max())
+        );
+
+        return Stream.of(influxLineProtocol(summary.getId(), "histogram", fields));
+    }
+
+    private String influxLineProtocol(Meter.Id id, String metricType, Stream<Field> fields) {
+        String tags = getConventionTags(id).stream()
+                .filter(t -> StringUtils.isNotBlank(t.getValue()))
+                .map(t -> "," + t.getKey() + "=" + t.getValue())
+                .collect(joining(""));
+
+        return getConventionName(id)
+                + tags + ",metric_type=" + metricType + " "
+                + fields.map(Field::toString).collect(joining(","))
+                + " " + clock.wallTime();
+    }
+
+    @Override
+    protected final TimeUnit getBaseTimeUnit() {
+        return TimeUnit.MILLISECONDS;
+    }
+
+    public static class Builder {
+        private final SensuInfluxConfig config;
+
+        private Clock clock = Clock.SYSTEM;
+        private ThreadFactory threadFactory = DEFAULT_THREAD_FACTORY;
+
+        @SuppressWarnings("deprecation")
+        Builder(SensuInfluxConfig config) {
+            this.config = config;
+        }
+
+        public Builder clock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        public Builder threadFactory(ThreadFactory threadFactory) {
+            this.threadFactory = threadFactory;
+            return this;
+        }
+
+        public SensuInfluxMeterRegistry build() {
+            return new SensuInfluxMeterRegistry(config, clock, threadFactory);
+        }
+    }
+
+    class Field {
+        final String key;
+        final double value;
+
+        Field(String key, double value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return key + "=" + DoubleFormat.decimalOrNan(value);
+        }
+    }
+
+    static class SensuEvent {
+
+        private final String json;
+
+        SensuEvent(String sensuName, String output) {
+            json = "{" +
+                    "\"name\":\"" + sensuName + "\"," +
+                    "\"type\":\"metric\"," +
+                    "\"handlers\":[\"events_nano\"]," +
+                    "\"output\":\"" + output + "\"," +
+                    "\"status\":0" +
+                    "}";
+        }
+
+        String getJson() {
+            return json;
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/medlemskap/common/influx/SensuInfluxNamingConvention.java
+++ b/src/main/kotlin/no/nav/medlemskap/common/influx/SensuInfluxNamingConvention.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2019 NAV
+ * <p>
+ * MIT License
+ * <p>
+ * This file incorporates works covered by the following copyright and permission notice:
+ * ---
+ * <p>
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.nav.medlemskap.common.influx;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.lang.Nullable;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@link NamingConvention} for Influx.
+ * Modified from{@link io.micrometer.influx.InfluxNamingConvention}.
+ *
+ * @see <a href="https://github.com/micrometer-metrics/micrometer/tree/v1.3.5/implementations/micrometer-registry-influx">https://github.com/micrometer-metrics/micrometer/tree/v1.3.5/implementations/micrometer-registry-influx</a>
+ **/
+public class SensuInfluxNamingConvention implements NamingConvention {
+
+    // https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_reference/#special-characters
+    private static final Pattern PATTERN_SPECIAL_CHARACTERS = Pattern.compile("([, =\"])");
+
+    private final NamingConvention delegate;
+
+    /**
+     * By default, telegraf's configuration option for {@code metric_separator}
+     * is an underscore, which corresponds to {@link NamingConvention#snakeCase}.
+     */
+    public SensuInfluxNamingConvention() {
+        this(NamingConvention.snakeCase);
+    }
+
+    public SensuInfluxNamingConvention(NamingConvention delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String name(String name, Meter.Type type, @Nullable String baseUnit) {
+        return escape(delegate.name(name, type, baseUnit).replace("=", "_"));
+    }
+
+    @Override
+    public String tagKey(String key) {
+        // `time` cannot be a field key or tag key
+        if (key.equals("time"))
+            throw new IllegalArgumentException("'time' is an invalid tag key in InfluxDB");
+        return escape(delegate.tagKey(key));
+    }
+
+    @Override
+    public String tagValue(String value) {
+        // `time` cannot be a field key or tag key
+        if (value.equals("time"))
+            throw new IllegalArgumentException("'time' is an invalid tag value in InfluxDB");
+        return escape(this.delegate.tagValue(value));
+    }
+
+    private String escape(String string) {
+        return PATTERN_SPECIAL_CHARACTERS.matcher(string).replaceAll("\\\\$1");
+    }
+}


### PR DESCRIPTION
The code in this PR is based upon code in the Micrometer project (https://github.com/micrometer-metrics/micrometer/tree/v1.3.5/implementations/micrometer-registry-influx), but modified to fit our need of sending metrics to Influx by way of the Sensu service in Nais. (Ref https://github.com/nais/doc/blob/master/observability/metrics.md)

I have tried to add the necessary legal files and changes to do this the proper way.

The SensuEvent and the Socket code for writing to Sensu is copied from the NAV-project "pam-annonsemottak" (https://github.com/navikt/pam-annonsemottak/blob/0.60.187-30e7a2a/src/main/java/no/nav/pam/annonsemottak/app/metrics/SensuClient.java). They already write metrics to Influx, but they don't use Micrometer for it.