### PR TITLE
Norsk arbeidsgiver: Konkurssjekk på status fra ereg 1 4 

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/domene/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/domene/Arbeidsforhold.kt
@@ -20,7 +20,8 @@ data class Arbeidsavtale (
 data class Arbeidsgiver (
         val type: String?,
         val landkode: String?,
-        val antallAnsatte: Int?
+        val antallAnsatte: Int?,
+        val konkursStatus: List<String>?
 )
 
 data class Utenlandsopphold (

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
@@ -26,6 +26,8 @@ object Funksjoner {
 
     infix fun String?.erDelAv(map: Map<String, String>) = map.containsKey(this)
 
+    fun List<String>.erOver() = this.isNullOrEmpty()
+
     fun List<Any>.erTom() = this.isNullOrEmpty()
 
     fun List<Any>.erIkkeTom() = !erTom()

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
@@ -32,6 +32,7 @@ object Funksjoner {
 
     fun List<Any>.erIkkeTom() = !erTom()
 
+
     infix fun List<Arbeidsforhold>.kunEr(tall: Int) = this.size == tall
 
     infix fun List<Int?>.alleErOver(tall: Int) = !this.stream().anyMatch { p -> p == null || p <= tall}

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
@@ -26,7 +26,6 @@ object Funksjoner {
 
     infix fun String?.erDelAv(map: Map<String, String>) = map.containsKey(this)
 
-    fun List<String>.erOver() = this.isNullOrEmpty()
 
     fun List<Any>.erTom() = this.isNullOrEmpty()
 

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
@@ -24,13 +24,7 @@ object Funksjoner {
 
     infix fun Map<String, String>.finnesI(liste: List<String>) = this.keys.intersect(liste).isNotEmpty()
 
-    infix fun String?.erDelAv(map: Map<String, String>) = map.containsKey(this)
-
-
-    fun List<Any>.erTom() = this.isNullOrEmpty()
-
-    fun List<Any>.erIkkeTom() = !erTom()
-
+    fun List<Any>?.erTom() = this == null || this.isNullOrEmpty()
 
     infix fun List<Arbeidsforhold>.kunEr(tall: Int) = this.size == tall
 

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
@@ -110,7 +110,8 @@ class Personfakta(private val datagrunnlag: Datagrunnlag) {
         return periodeDatagrunnlag.overlaps(lagInterval(periode)) || periodeDatagrunnlag.encloses(lagInterval(periode))
     }
 
-    fun hentKonkursStatus(): List<String>? {
+    fun hentKonkursStatuser(): List<String>? {
       return arbeidsforholdForNorskArbeidsgiver().flatMap { it.arbeidsgiver.konkursStatus.orEmpty() }
     }
 }
+

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
@@ -109,4 +109,8 @@ class Personfakta(private val datagrunnlag: Datagrunnlag) {
     private fun periodefilter(periodeDatagrunnlag: Interval, periode: Periode): Boolean {
         return periodeDatagrunnlag.overlaps(lagInterval(periode)) || periodeDatagrunnlag.encloses(lagInterval(periode))
     }
+
+    fun hentKonkursStatus(): List<String>? {
+      return arbeidsforholdForNorskArbeidsgiver().flatMap { it.arbeidsgiver.konkursStatus.orEmpty() }
+    }
 }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
@@ -8,7 +8,6 @@ import no.nav.medlemskap.regler.common.Funksjoner.inneholder
 import no.nav.medlemskap.regler.common.Funksjoner.inneholderNoe
 import no.nav.medlemskap.regler.common.Funksjoner.kunEr
 import no.nav.medlemskap.regler.common.Funksjoner.kunInneholder
-import no.nav.medlemskap.regler.common.Funksjoner.erOver
 import no.nav.medlemskap.regler.common.Funksjoner.erTom
 
 class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
@@ -100,7 +99,7 @@ class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
             personfakta.erArbeidsgivereOrganisasjon()
                     && personfakta.antallAnsatteHosArbeidsgivere() alleErOver 5
                     && personfakta.harSammenhengendeArbeidsforholdSiste12Mnd()
-                    && personfakta.hentKonkursStatuser().isNullOrEmpty() -> ja()
+                    && personfakta.hentKonkursStatuser()!!.erTom() -> ja()
             else -> nei("Arbeidsgiver er ikke norsk. Land: ${personfakta.arbeidsgiversLandForPeriode()}")
         }
     }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
@@ -99,7 +99,7 @@ class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
             personfakta.erArbeidsgivereOrganisasjon()
                     && personfakta.antallAnsatteHosArbeidsgivere() alleErOver 5
                     && personfakta.harSammenhengendeArbeidsforholdSiste12Mnd()
-                    && personfakta.hentKonkursStatuser()!!.erTom() -> ja()
+                    && personfakta.hentKonkursStatuser().erTom() -> ja()
             else -> nei("Arbeidsgiver er ikke norsk. Land: ${personfakta.arbeidsgiversLandForPeriode()}")
         }
     }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
@@ -8,6 +8,7 @@ import no.nav.medlemskap.regler.common.Funksjoner.inneholder
 import no.nav.medlemskap.regler.common.Funksjoner.inneholderNoe
 import no.nav.medlemskap.regler.common.Funksjoner.kunEr
 import no.nav.medlemskap.regler.common.Funksjoner.kunInneholder
+import no.nav.medlemskap.regler.common.Funksjoner.erOver
 
 class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
 
@@ -97,7 +98,8 @@ class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
         return when {
             personfakta.erArbeidsgivereOrganisasjon()
                     && personfakta.antallAnsatteHosArbeidsgivere() alleErOver 5
-                    && personfakta.harSammenhengendeArbeidsforholdSiste12Mnd() -> ja()
+                    && personfakta.harSammenhengendeArbeidsforholdSiste12Mnd()
+                    && personfakta.hentKonkursStatus().isNullOrEmpty() -> ja()
             else -> nei("Arbeidsgiver er ikke norsk. Land: ${personfakta.arbeidsgiversLandForPeriode()}")
         }
     }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
@@ -9,6 +9,7 @@ import no.nav.medlemskap.regler.common.Funksjoner.inneholderNoe
 import no.nav.medlemskap.regler.common.Funksjoner.kunEr
 import no.nav.medlemskap.regler.common.Funksjoner.kunInneholder
 import no.nav.medlemskap.regler.common.Funksjoner.erOver
+import no.nav.medlemskap.regler.common.Funksjoner.erTom
 
 class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
 
@@ -99,7 +100,7 @@ class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
             personfakta.erArbeidsgivereOrganisasjon()
                     && personfakta.antallAnsatteHosArbeidsgivere() alleErOver 5
                     && personfakta.harSammenhengendeArbeidsforholdSiste12Mnd()
-                    && personfakta.hentKonkursStatus().isNullOrEmpty() -> ja()
+                    && personfakta.hentKonkursStatuser().isNullOrEmpty() -> ja()
             else -> nei("Arbeidsgiver er ikke norsk. Land: ${personfakta.arbeidsgiversLandForPeriode()}")
         }
     }

--- a/src/main/kotlin/no/nav/medlemskap/services/aareg/AaRegClient.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/aareg/AaRegClient.kt
@@ -16,6 +16,7 @@ import no.nav.medlemskap.domene.ArbeidsgiverOrg
 import no.nav.medlemskap.domene.ArbeidsgiverPerson
 import no.nav.medlemskap.services.ereg.Bruksperiode
 import no.nav.medlemskap.services.ereg.EregClient
+import no.nav.medlemskap.services.ereg.Status
 import no.nav.medlemskap.services.pdl.PdlClient
 import no.nav.medlemskap.services.runWithRetryAndMetrics
 import no.nav.medlemskap.services.sts.StsRestClient
@@ -110,7 +111,9 @@ class AaRegService(
             dataOmArbeidsgiver[orgnummer] = ArbeidsgiverInfo(
                     arbeidsgiverEnhetstype = hentArbeidsgiverEnhetstype(orgnummer, callId),
                     antallAnsatte = organisasjon.organisasjonDetaljer?.ansatte?.associateBy({ ansatte -> ansatte.bruksperiode }, { ansatte -> ansatte.antall })?.get(Bruksperiode(fraOgMed, tilOgMed)),
-                    opphoersdato = organisasjon.organisasjonDetaljer?.opphoersdato
+                    opphoersdato = organisasjon.organisasjonDetaljer?.opphoersdato,
+                    konkursStatus = organisasjon.organisasjonDetaljer?.statuser?.map{it -> it.kode}
+
 
             )
         }
@@ -122,7 +125,7 @@ class AaRegService(
         return mapAaregResultat(arbeidsforhold, dataOmArbeidsgiver, dataOmPerson)
     }
 
-    data class ArbeidsgiverInfo(val arbeidsgiverEnhetstype: String?, val antallAnsatte: Int?, val opphoersdato: LocalDate?)
+    data class ArbeidsgiverInfo(val arbeidsgiverEnhetstype: String?, val antallAnsatte: Int?, val opphoersdato: LocalDate?, val konkursStatus: List<String>?)
 
 
     private suspend fun hentArbeidsgiverEnhetstype(orgnummer: String, callId: String): String? {

--- a/src/main/kotlin/no/nav/medlemskap/services/aareg/AaregMapper.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/aareg/AaregMapper.kt
@@ -63,8 +63,12 @@ fun mapArbeidsgiver(arbeidsforhold: AaRegArbeidsforhold, dataOmArbeidsgiver: Mut
     val enhetstype = dataOmArbeidsgiver[arbeidsforhold.arbeidsgiver.organisasjonsnummer]?.arbeidsgiverEnhetstype
     val antallAnsatte = dataOmArbeidsgiver[arbeidsforhold.arbeidsgiver.organisasjonsnummer]?.antallAnsatte
     val arbeidsgiversLand = dataOmPerson[arbeidsforhold.arbeidsgiver.offentligIdent ?: arbeidsforhold.arbeidsgiver.aktoerId]
-
-    return Arbeidsgiver(enhetstype, arbeidsgiversLand, antallAnsatte)
+    val konkursStatus = dataOmArbeidsgiver[arbeidsforhold.arbeidsgiver.organisasjonsnummer]?.konkursStatus
+    return Arbeidsgiver(
+                        type = enhetstype,
+                        landkode = arbeidsgiversLand,
+                        antallAnsatte = antallAnsatte,
+                        konkursStatus = konkursStatus)
 }
 
 fun mapPeriodeTilArbeidsavtale(arbeidsavtale: AaRegArbeidsavtale): Periode {

--- a/src/test/kotlin/no/nav/medlemskap/regler/personer/Personleser.kt
+++ b/src/test/kotlin/no/nav/medlemskap/regler/personer/Personleser.kt
@@ -34,7 +34,7 @@ class Personleser {
     fun norskMedFlereArbeidsforholdstyperIPerioder() = lesDatagrunnlag("$variertDatagrunnlagArbeidsforhold/norsk_og_flere_arbeidsforholdtyper_i_periode.json")
     fun norskMedFlereYrkeskoderIPeriode () = lesDatagrunnlag("$variertDatagrunnlagArbeidsforhold/norsk_med_flere_yrkestyper_i_periode.json")
     fun enkelNorskFlereArbeidsforholdIPeriode() = lesDatagrunnlag("$variertDatagrunnlagArbeidsforhold/norsk_med_flere_yrkestyper_i_periode.json")
-
+    fun enkelNorskMedKonkursArbeidsgiver() = lesDatagrunnlag("$variertDatagrunnlagArbeidsforhold/norsk_med_konkurs_arbeidsgiver.json")
 
 
 

--- a/src/test/kotlin/no/nav/medlemskap/regler/v1/RegelsettForNorskLovvalgTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/regler/v1/RegelsettForNorskLovvalgTest.kt
@@ -30,6 +30,11 @@ class RegelsettForNorskLovvalgTest {
     }
 
     @Test
+    fun  `person med ett arbeidsforhold med arbeidsgiver har konkurs status får uavklart`() {
+        assertEquals(Svar.UAVKLART, evaluer(personleser.enkelNorskMedKonkursArbeidsgiver()))
+    }
+
+    @Test
     fun `person med flere arbeidsforhold hvorav en arbeidsgiver har færre enn 6 ansatte innenfor kontrollperiode, får uavklart`() {
         assertEquals(Svar.UAVKLART, evaluer(personleser.norskMedFlereArbeidsforholdHvoravEnArbeidsgiverMedKun4AnsatteIPeriode()))
     }

--- a/src/test/resources/testpersoner/variertDatagrunnlagIPeriode/arbeidsforhold/norsk_med_konkurs_arbeidsgiver.json
+++ b/src/test/resources/testpersoner/variertDatagrunnlagIPeriode/arbeidsforhold/norsk_med_konkurs_arbeidsgiver.json
@@ -31,10 +31,10 @@
         "type": "Organisasjon",
         "identifikator": "1",
         "landkode": "NOR",
-        "antallAnsatte": "5"
+        "antallAnsatte": "10",
+        "konkursStatus" : ["OSKP"]
       },
       "arbeidsfolholdstype": "NORMALT",
-      "konkursStatuser" : ["OSKP"],
       "arbeidsavtaler": [
         {
           "periode": {

--- a/src/test/resources/testpersoner/variertDatagrunnlagIPeriode/arbeidsforhold/norsk_med_konkurs_arbeidsgiver.json
+++ b/src/test/resources/testpersoner/variertDatagrunnlagIPeriode/arbeidsforhold/norsk_med_konkurs_arbeidsgiver.json
@@ -1,0 +1,52 @@
+{
+  "periode": {
+    "fom": "2020-01-30",
+    "tom": "2021-01-30"
+  },
+  "brukerinput" : {
+    "arbeidUtenforNorge" : false
+  },
+  "personhistorikk" : {
+    "statsborgerskap" : [
+      {
+        "landkode" : "NOR",
+        "fom" : "1991-06-30",
+        "tom" : null
+      }
+    ],
+    "personstatuser" : [ ],
+    "bostedsadresser" : [ ],
+    "postadresser" : [ ],
+    "midlertidigAdresser" : [ ]
+  },
+  "medlemskapsunntak" : [ ],
+  "arbeidsforhold" : [
+    {
+      "periode": {
+        "fom": "2018-01-01",
+        "tom": "2022-06-30"
+      },
+      "utenlandsopphold": [],
+      "arbeidsgiver": {
+        "type": "Organisasjon",
+        "identifikator": "1",
+        "landkode": "NOR",
+        "antallAnsatte": "5"
+      },
+      "arbeidsfolholdstype": "NORMALT",
+      "konkursStatuser" : ["OSKP"],
+      "arbeidsavtaler": [
+        {
+          "periode": {
+            "fom": "2020-01-30",
+            "tom": "2020-06-30"
+          },
+          "yrkeskode": "0001"
+        }
+      ]
+    }
+  ],
+  "inntekt" : [ ],
+  "oppgaver" : [ ],
+  "dokument" : [ ]
+}


### PR DESCRIPTION
I følge 1.4 "Er arbeidgiver norsk" er man nødt til å sjekke om organisasjonen har satt en status som vil fortelle om enheten er under konkurs. Opphørsdato som var først tenkt kan bli satt et år etter en bedrift har startet konkursprosessen. 