### PR TITLE
Periodesjekk: Regel 1.5, 1.5.1 og 1.6 (Periodeuthenting for arbeidsforhold)

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Datohjelper.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Datohjelper.kt
@@ -35,6 +35,15 @@ class Datohjelper(val datagrunnlag: Datagrunnlag) {
 
     }
 
+    fun kontrollPeriodeForYrkeskode(): Periode{
+        return when(ytelse){
+            Ytelse.SYKEPENGER -> Periode(
+                    fom = førsteSykedag().minusDays(12),
+                    tom = førsteSykedag()
+            )
+        }
+    }
+
     fun kontrollPeriodeForYrkesforholdType(): Periode {
         return when(ytelse){
             Ytelse.SYKEPENGER -> Periode(

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Datohjelper.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Datohjelper.kt
@@ -52,6 +52,15 @@ class Datohjelper(val datagrunnlag: Datagrunnlag) {
             )
         }
     }
+
+    fun kontrollPeriodeForSkipsregister(): Periode {
+        return when(ytelse){
+            Ytelse.SYKEPENGER -> Periode(
+                    fom = førsteSykedag().minusMonths(12),
+                    tom = førsteSykedag()
+            )
+        }
+    }
 }
 
 fun lagInterval(periode: Periode): Interval {

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
@@ -16,7 +16,7 @@ object Funksjoner {
 
     infix fun List<String>.inneholder(string: String) = this.contains(string)
 
-    infix fun List<String>.alleEr(string: String) = this.distinct().size > 1
+    infix fun List<String>.alleEr(string: String) = this.stream().allMatch { m -> m.equals(string)}
 
     infix fun List<String>.kunInneholder(string: String) = this.contains(string) && this.size == 1
 

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
@@ -16,6 +16,8 @@ object Funksjoner {
 
     infix fun List<String>.inneholder(string: String) = this.contains(string)
 
+    infix fun List<String>.alleEr(string: String) = this.distinct().size > 1
+
     infix fun List<String>.kunInneholder(string: String) = this.contains(string) && this.size == 1
 
     infix fun Map<String, String>.harAlle(liste: List<Statsborgerskap>) = this.keys.containsAll(liste.stream().map { it.landkode }.collect(Collectors.toList()))

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
@@ -92,7 +92,10 @@ class Personfakta(private val datagrunnlag: Datagrunnlag) {
     }
 
     fun sisteArbeidsforholdYrkeskode(): List<String> {
-        return arbeidsforhold().flatMap { it.arbeidsavtaler }.map { it.yrkeskode }
+        return datagrunnlag.arbeidsforhold.filter {
+            periodefilter(lagInterval(Periode(it.periode.fom, it.periode.tom)),
+                    datohjelper.kontrollPeriodeForYrkeskode())}
+                .flatMap { it.arbeidsavtaler }.map { it.yrkeskode }
     }
 
     fun sisteArbeidsforholdSkipsregister(): List<String> {

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
@@ -47,11 +47,11 @@ class Personfakta(private val datagrunnlag: Datagrunnlag) {
 
     //Sjekker her at det ikke finnes "brudd" i perioden mens sjekken for
     // selve typen gjøres i regeltjenesten
-    fun arbeidsforholdForYrkestype(): List<Arbeidsforhold> {
+    fun arbeidsforholdForYrkestype(): List<String> {
         return datagrunnlag.arbeidsforhold.filter {
             periodefilter(lagInterval(Periode(it.periode.fom, it.periode.tom)),
                     datohjelper.kontrollPeriodeForYrkesforholdType())
-        }
+        }.map { it.arbeidsfolholdstype.navn}
     }
 
     fun arbeidsgivereIArbeidsforholdForNorskArbeidsgiver(): List<Arbeidsgiver> {

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Personfakta.kt
@@ -44,6 +44,16 @@ class Personfakta(private val datagrunnlag: Datagrunnlag) {
         }
     }
 
+
+    //Sjekker her at det ikke finnes "brudd" i perioden mens sjekken for
+    // selve typen gjøres i regeltjenesten
+    fun arbeidsforholdForYrkestype(): List<Arbeidsforhold> {
+        return datagrunnlag.arbeidsforhold.filter {
+            periodefilter(lagInterval(Periode(it.periode.fom, it.periode.tom)),
+                    datohjelper.kontrollPeriodeForYrkesforholdType())
+        }
+    }
+
     fun arbeidsgivereIArbeidsforholdForNorskArbeidsgiver(): List<Arbeidsgiver> {
         return arbeidsforholdForNorskArbeidsgiver().stream().map { it.arbeidsgiver }.collect(Collectors.toList())
     }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
@@ -9,6 +9,7 @@ import no.nav.medlemskap.regler.common.Funksjoner.inneholderNoe
 import no.nav.medlemskap.regler.common.Funksjoner.kunEr
 import no.nav.medlemskap.regler.common.Funksjoner.kunInneholder
 import no.nav.medlemskap.regler.common.Funksjoner.erTom
+import no.nav.medlemskap.regler.common.Funksjoner.alleEr
 
 class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
 
@@ -106,7 +107,7 @@ class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
 
     private fun sjekkMaritim(): Resultat =
             when {
-                personfakta.sisteArbeidsforholdtype() kunInneholder Arbeidsforholdstype.MARITIM.navn -> ja()
+                personfakta.arbeidsforholdForYrkestype() alleEr Arbeidsforholdstype.MARITIM.navn -> ja()
                 else -> nei()
             }
 

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForArbeidsforhold.kt
@@ -106,7 +106,7 @@ class ReglerForArbeidsforhold(val personfakta: Personfakta) : Regler() {
 
     private fun sjekkMaritim(): Resultat =
             when {
-                personfakta.sisteArbeidsforholdtype() inneholder Arbeidsforholdstype.MARITIM.navn -> ja()
+                personfakta.sisteArbeidsforholdtype() kunInneholder Arbeidsforholdstype.MARITIM.navn -> ja()
                 else -> nei()
             }
 


### PR DESCRIPTION
Endret litt på regel 1.5 og 1.6 etter endringer fra helle og for å ha en egen metode til å hente ut arbeidsforholdene som skal brukes til denne regelen. Men ønsker gjerne at noen går over datohjelper klassen og sjekker at dette ser riktig ut. 