### PR TITLE
Lagt på retry på helsesjekkene

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/common/healthcheck/HealthService.kt
+++ b/src/main/kotlin/no/nav/medlemskap/common/healthcheck/HealthService.kt
@@ -31,7 +31,7 @@ class HealthService(
             futures.awaitAll()
         }
         results.filterIsInstance<UnHealthy>().forEach {
-            logger.error("Failing Health Check: $it")
+            logger.info("Failing Health Check: $it")
         }
         return results
     }

--- a/src/main/kotlin/no/nav/medlemskap/services/Services.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/Services.kt
@@ -46,6 +46,7 @@ class Services(val configuration: Configuration) {
 
     val healthService: HealthService
     private val healthReporter: HealthReporter
+    private val healthRetry = retryRegistry.retry("Helsesjekker")
 
     private val stsRetry = retryRegistry.retry("STS")
     private val tpsRetry = retryRegistry.retry("TPS")
@@ -93,13 +94,13 @@ class Services(val configuration: Configuration) {
 
         healthService = HealthService(setOf(
                 //HttpResponseHealthCheck("AaReg", { aaRegClient.healthCheck() }),
-                HttpResponseHealthCheck("Inntekt", { inntektClient.healthCheck() }),
-                HttpResponseHealthCheck("Medl", { medlClient.healthCheck() }),
-                HttpResponseHealthCheck("Oppg", { oppgaveClient.healthCheck() }),
-                HttpResponseHealthCheck("PDL", { pdlClient.healthCheck() }),
-                HttpResponseHealthCheck("SAF", { safClient.healthCheck() }),
-                HttpResponseHealthCheck("STS", { stsRestClient.healthCheck() }),
-                TryCatchHealthCheck("TPS", { personClient.healthCheck() })
+                HttpResponseHealthCheck("Inntekt", { inntektClient.healthCheck() }, healthRetry),
+                HttpResponseHealthCheck("Medl", { medlClient.healthCheck() }, healthRetry),
+                HttpResponseHealthCheck("Oppg", { oppgaveClient.healthCheck() }, healthRetry),
+                HttpResponseHealthCheck("PDL", { pdlClient.healthCheck() }, healthRetry),
+                HttpResponseHealthCheck("SAF", { safClient.healthCheck() }, healthRetry),
+                HttpResponseHealthCheck("STS", { stsRestClient.healthCheck() }, healthRetry),
+                TryCatchHealthCheck("TPS", { personClient.healthCheck() }, healthRetry)
         ))
 
         healthReporter = HealthReporter(healthService)


### PR DESCRIPTION
samt justert ned loggnivå på oppsummeringen av unhealthy sjekker da det ga dobbelt-logging

Retry på helsesjekkene ble anbefalt i en Slack-kanal. Jeg la det med vilje ikke til tidligere, men når jeg ser hvor mye hickups det er til tider, så tenker jeg at det kan være smart likevel.