### PR TITLE
Ryddet opp i logging, påkrevd azp-uthenting

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/common/JwtConfig.kt
+++ b/src/main/kotlin/no/nav/medlemskap/common/JwtConfig.kt
@@ -12,7 +12,6 @@ import java.net.URL
 import java.util.concurrent.TimeUnit
 
 private val logger = KotlinLogging.logger { }
-private val secureLogger = KotlinLogging.logger("tjenestekall")
 
 class JwtConfig(val configuration: Configuration, azureAdOpenIdConfiguration: AzureAdOpenIdConfiguration) {
 
@@ -30,8 +29,6 @@ class JwtConfig(val configuration: Configuration, azureAdOpenIdConfiguration: Az
         return try {
             requireNotNull(credentials.payload.audience) { "Auth: Audience mangler i token" }
             require(credentials.payload.audience.contains(configuration.azureAd.jwtAudience)) { "Auth: Ugyldig audience i token" }
-            val azp = credentials.payload.getClaim("azp").asString()
-            secureLogger.info("azp verdi fra credentials i JwtConfig: $azp")
             JWTPrincipal(credentials.payload)
         } catch (e: Exception) {
             logger.error(e) { "Failed to validate token" }

--- a/src/main/kotlin/no/nav/medlemskap/common/JwtConfig.kt
+++ b/src/main/kotlin/no/nav/medlemskap/common/JwtConfig.kt
@@ -30,8 +30,7 @@ class JwtConfig(val configuration: Configuration, azureAdOpenIdConfiguration: Az
         return try {
             requireNotNull(credentials.payload.audience) { "Auth: Audience mangler i token" }
             require(credentials.payload.audience.contains(configuration.azureAd.jwtAudience)) { "Auth: Ugyldig audience i token" }
-            secureLogger.info { "credentials claims fra JwtConfig: " + credentials.payload.claims }
-            var azp = credentials.payload.getClaim("azp").asString()
+            val azp = credentials.payload.getClaim("azp").asString()
             secureLogger.info("azp verdi fra credentials i JwtConfig: $azp")
             JWTPrincipal(credentials.payload)
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/medlemskap/routes/EvalueringRoute.kt
+++ b/src/main/kotlin/no/nav/medlemskap/routes/EvalueringRoute.kt
@@ -38,13 +38,10 @@ fun Routing.evalueringRoute(
         authenticate {
             post("/") {
                 apiCounter().increment()
-                val callerPrincipal: JWTPrincipal? = call.authentication.principal()
-                val subject = callerPrincipal?.payload?.subject ?: "ukjent"
-                secureLogger.info("Mottar principal {} med subject {}", callerPrincipal, subject)
-                val azp = callerPrincipal?.payload?.getClaim("azp")?.asString() ?: "ukjent"
+
+                val callerPrincipal: JWTPrincipal = call.authentication.principal()!!
+                val azp = callerPrincipal.payload.getClaim("azp").asString()
                 secureLogger.info("EvalueringRoute: azp-claim i principal-token: {}", azp)
-                val claims = callerPrincipal?.payload?.claims?.toString() ?: "ukjent"
-                secureLogger.info("EvalueringRoute: alle claims: {}", claims)
 
                 val request = validerRequest(call.receive())
                 val callId = call.callId ?: UUID.randomUUID().toString()
@@ -74,11 +71,6 @@ fun Routing.evalueringRoute(
         logger.info("autentiserer IKKE kallet")
         post("/") {
             apiCounter().increment()
-            val callerPrincipal: JWTPrincipal? = call.authentication.principal()
-            val subject = callerPrincipal?.payload?.subject ?: "ukjent"
-            secureLogger.info("Mottar principal {} med subject {}", callerPrincipal, subject)
-            val azp = callerPrincipal?.payload?.getClaim("azp")?.asString() ?: "ukjent"
-            secureLogger.info("EvalueringRoute: azp-claim i principal-token:", azp)
             val request = validerRequest(call.receive())
             val callId = call.callId ?: UUID.randomUUID().toString()
             //konsumentCounter(subject).increment()


### PR DESCRIPTION
Har fjernet en hel del av loggingen vi la til ifm feilsøkingen i går. Har gjort om azp-uthentingen så Principal er påkrevd, med !!. Hvis vi får null vil koden nå tryne med en NullPointerException, noe jeg tenker kan være en fordel, for det betyr jo at autentiseringen ikke fungerer..