### PR TITLE
Endret oppsett paa adresser og la inn sjekk for midlertidige adresser…

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Funksjoner.kt
@@ -30,6 +30,8 @@ object Funksjoner {
 
     fun List<Any>?.erTom() = this == null || this.isNullOrEmpty()
 
+    fun List<Any>?.erIkkeTom() = !erTom()
+
     fun List<String?>?.finnes() = this != null && this.isNotEmpty()
 
     infix fun List<Int?>.finnesMindreEnn(tall: Int) = this.stream().anyMatch { p -> p == null || p < tall }

--- a/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/AdresseFunksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/AdresseFunksjoner.kt
@@ -14,7 +14,7 @@ object AdresseFunksjoner {
     fun List<Adresse>.adresserSiste12Mnd(kontrollPeriode: Periode): List<Adresse> =
             this.filter {it.adressensPeriodeOverlapperKontrollPerioden(kontrollPeriode) }
 
-    fun List<Adresse>.landekodeTilAdresseSiste12Mnd(kontrollPeriode: Periode): List<String> =
+    fun List<Adresse>.landkodeTilAdresseSiste12Mnd(kontrollPeriode: Periode): List<String> =
             this.adresserSiste12Mnd(kontrollPeriode).map {it.landkode }
 
     fun List<Adresse>.harSammeAdressePaaGitteDatoer(dato1: LocalDate, dato2: LocalDate): Boolean =

--- a/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/AdresseFunksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/AdresseFunksjoner.kt
@@ -14,8 +14,11 @@ object AdresseFunksjoner {
     fun Adresse.adressensPeriodeOverlapperKontrollPerioden(kontrollPeriode: Periode) =
             Funksjoner.periodefilter(lagInterval(Periode(this.fom, this.tom)), kontrollPeriode)
 
-    fun List<Adresse>.harBrukerNorskAdresseInnenforSiste12Mnd(kontrollPeriode: Periode): Boolean =
-            this.any { it.adresseLandskodeErNorsk() && it.adressensPeriodeOverlapperKontrollPerioden(kontrollPeriode) }
+    fun List<Adresse>.adresserSiste12Mnd(kontrollPeriode: Periode): List<Adresse> =
+            this.filter {it.adressensPeriodeOverlapperKontrollPerioden(kontrollPeriode) }
+
+    fun List<Adresse>.landekodeTilAdresseSiste12Mnd(kontrollPeriode: Periode): List<String> =
+            this.adresserSiste12Mnd(kontrollPeriode).map {it.landkode }
 
     fun List<Adresse>.harSammeAdressePaaGitteDatoer(dato1: LocalDate, dato2: LocalDate): Boolean =
             this.adresseForDato(dato1).size == 1 &&
@@ -23,5 +26,7 @@ object AdresseFunksjoner {
 
     infix fun List<Adresse>.adresseForDato(dato: LocalDate) =
             this.filter { Funksjoner.periodefilter(lagInterval(Periode(it.fom, it.tom)), Periode(dato, dato)) }
+
+
 
 }

--- a/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/AdresseFunksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/AdresseFunksjoner.kt
@@ -8,9 +8,6 @@ import java.time.LocalDate
 
 object AdresseFunksjoner {
 
-
-    fun Adresse.adresseLandskodeErNorsk() = this.landkode == "NOR"
-
     fun Adresse.adressensPeriodeOverlapperKontrollPerioden(kontrollPeriode: Periode) =
             Funksjoner.periodefilter(lagInterval(Periode(this.fom, this.tom)), kontrollPeriode)
 

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
@@ -7,7 +7,7 @@ import no.nav.medlemskap.regler.common.Funksjoner.erIkkeTom
 import no.nav.medlemskap.regler.common.Funksjoner.erTom
 import no.nav.medlemskap.regler.common.Funksjoner.alleEr
 import no.nav.medlemskap.regler.funksjoner.AdresseFunksjoner.adresserSiste12Mnd
-import no.nav.medlemskap.regler.funksjoner.AdresseFunksjoner.landekodeTilAdresseSiste12Mnd
+import no.nav.medlemskap.regler.funksjoner.AdresseFunksjoner.landkodeTilAdresseSiste12Mnd
 import no.nav.medlemskap.regler.funksjoner.ArbeidsforholdFunksjoner.harBrukerJobbetMerEnnGittStillingsprosentTilEnhverTid
 import no.nav.medlemskap.regler.funksjoner.StatsborgerskapFunksjoner.hentStatsborgerskapVedSluttAvKontrollperiode
 import no.nav.medlemskap.regler.funksjoner.StatsborgerskapFunksjoner.hentStatsborgerskapVedStartAvKontrollperiode
@@ -98,8 +98,8 @@ class ReglerForLovvalg(val datagrunnlag: Datagrunnlag) : Regler() {
 
     private fun sjekkLandkode(): Resultat {
         val bostedsadresser = bostedsadresser.adresserSiste12Mnd(kontrollPeriodeForPersonhistorikk)
-        val postadresserLandkoder = postadresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
-        val midlertidigadresserLandkoder = midlertidigAdresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
+        val postadresserLandkoder = postadresser.landkodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
+        val midlertidigadresserLandkoder = midlertidigAdresser.landkodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
 
         return when {
             bostedsadresser.erIkkeTom()

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
@@ -63,7 +63,7 @@ class ReglerForLovvalg(val datagrunnlag: Datagrunnlag) : Regler() {
             identifikator = "10",
             avklaring = "Er bruker folkeregistrert som bosatt i Norge og har vært det i 12 mnd?",
             beskrivelse = "",
-            operasjon = { sjekkLandekodePaaAdresser() }
+            operasjon = { sjekkLandekode() }
     )
 
     private val harBrukerNorskStatsborgerskap = Regel(
@@ -96,15 +96,15 @@ class ReglerForLovvalg(val datagrunnlag: Datagrunnlag) : Regler() {
         }
     }
 
-    private fun sjekkLandekodePaaAdresser(): Resultat {
-        val bostedsadresseSiste12Mnd = bostedsadresser.adresserSiste12Mnd(kontrollPeriodeForPersonhistorikk)
-        val postAdresseLandekodeSiste12Mnd = postadresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
-        val midlertidigAdresseLandekodeSiste12Mnd = midlertidigAdresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
+    private fun sjekkLandekode(): Resultat {
+        val bostedsadresser = bostedsadresser.adresserSiste12Mnd(kontrollPeriodeForPersonhistorikk)
+        val postadresserLandekoder = postadresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
+        val midlertidigadresserLandekoder = midlertidigAdresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
 
         return when {
-            bostedsadresseSiste12Mnd.erIkkeTom()
-                    && (postAdresseLandekodeSiste12Mnd alleEr "NOR" || postAdresseLandekodeSiste12Mnd.erTom())
-                    && (midlertidigAdresseLandekodeSiste12Mnd alleEr "NOR" || midlertidigAdresseLandekodeSiste12Mnd.erTom())-> ja()
+            bostedsadresser.erIkkeTom()
+                    && (postadresserLandekoder alleEr "NOR" || postadresserLandekoder.erTom())
+                    && (midlertidigadresserLandekoder alleEr "NOR" || midlertidigadresserLandekoder.erTom())-> ja()
             else -> nei("Ikke alle adressene til bruker er norske, eller bruker mangler bostedsadresse")
         }
     }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
@@ -63,7 +63,7 @@ class ReglerForLovvalg(val datagrunnlag: Datagrunnlag) : Regler() {
             identifikator = "10",
             avklaring = "Er bruker folkeregistrert som bosatt i Norge og har vært det i 12 mnd?",
             beskrivelse = "",
-            operasjon = { sjekkLandekode() }
+            operasjon = { sjekkLandkode() }
     )
 
     private val harBrukerNorskStatsborgerskap = Regel(
@@ -96,7 +96,7 @@ class ReglerForLovvalg(val datagrunnlag: Datagrunnlag) : Regler() {
         }
     }
 
-    private fun sjekkLandekode(): Resultat {
+    private fun sjekkLandkode(): Resultat {
         val bostedsadresser = bostedsadresser.adresserSiste12Mnd(kontrollPeriodeForPersonhistorikk)
         val postadresserLandkoder = postadresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
         val midlertidigadresserLandkoder = midlertidigAdresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForLovvalg.kt
@@ -98,13 +98,13 @@ class ReglerForLovvalg(val datagrunnlag: Datagrunnlag) : Regler() {
 
     private fun sjekkLandekode(): Resultat {
         val bostedsadresser = bostedsadresser.adresserSiste12Mnd(kontrollPeriodeForPersonhistorikk)
-        val postadresserLandekoder = postadresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
-        val midlertidigadresserLandekoder = midlertidigAdresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
+        val postadresserLandkoder = postadresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
+        val midlertidigadresserLandkoder = midlertidigAdresser.landekodeTilAdresseSiste12Mnd(kontrollPeriodeForPersonhistorikk)
 
         return when {
             bostedsadresser.erIkkeTom()
-                    && (postadresserLandekoder alleEr "NOR" || postadresserLandekoder.erTom())
-                    && (midlertidigadresserLandekoder alleEr "NOR" || midlertidigadresserLandekoder.erTom())-> ja()
+                    && (postadresserLandkoder alleEr "NOR" || postadresserLandkoder.erTom())
+                    && (midlertidigadresserLandkoder alleEr "NOR" || midlertidigadresserLandkoder.erTom())-> ja()
             else -> nei("Ikke alle adressene til bruker er norske, eller bruker mangler bostedsadresse")
         }
     }

--- a/src/test/kotlin/no/nav/medlemskap/regler/personer/Personleser.kt
+++ b/src/test/kotlin/no/nav/medlemskap/regler/personer/Personleser.kt
@@ -23,12 +23,13 @@ class Personleser {
     fun enkelNorskPilot() = lesDatagrunnlag("$norsk/norsk_jobb_ikke_maritim_men_pilot.json")
     fun enkelNorskUtenlandskSkip() = lesDatagrunnlag("$norsk/norsk_jobb_maritim_utenlandsk_skip.json")
     fun norskDobbeltStatsborgerskap() = lesDatagrunnlag("$norsk/dobbelt_statsborgerskap.json")
-    fun norskBosattIUtland() = lesDatagrunnlag("$norsk/norsk_bosatt_i_utland.json")
-    fun norskPostadresseIUtland() = lesDatagrunnlag("$norsk/norsk_postadresse_i_utland.json")
+    fun norskUtenBostedsadresse() = lesDatagrunnlag("$norsk/norsk_bosatt_i_utland.json")
+    fun postadresseIUtland() = lesDatagrunnlag("$norsk/norsk_postadresse_i_utland.json")
     fun norskMedOpplysningerIMedl() = lesDatagrunnlag("$norsk/norsk_med_opplysninger_i_medl.json")
     fun norskUtenMedlemskapIMedl() = lesDatagrunnlag("$norsk/norsk_uten_medlemskap_i_medl.json")
     fun norskMedMedlemskapDelvisInnenfor12MndPeriode() = lesDatagrunnlag("$norsk/norsk_med_medlemskap_medl_delvis_innenfor_12_mnd_periode.json")
     fun norskUtenMedlemskapDelvisInnenfor12MndPeriode() = lesDatagrunnlag("$norsk/norsk_uten_medlemskap_medl_delvis_innenfor_12_mnd_periode.json")
+    fun midlertidigAdresseIUtland() = lesDatagrunnlag("$norsk/midlertidig_adresse_i_utland.json")
 
     fun norskMedFlereStatsborgerskap() = lesDatagrunnlag("$variertDatagrunnlag/norsk_flere_statsborgerskap_i_periode.json")
     fun norskMedUlikeEøsStatsborgerskap() = lesDatagrunnlag("$variertDatagrunnlag/norsk_ulike_eøs_statsborgerskap.json")
@@ -90,6 +91,8 @@ class Personleser {
     fun dataGrunnlagFraJson(json: String): Datagrunnlag {
         return objectMapper.readValue(json, Datagrunnlag::class.java)
     }
+
+
 
     companion object {
         val norsk = "/testpersoner/norske"

--- a/src/test/kotlin/no/nav/medlemskap/regler/personer/Personleser.kt
+++ b/src/test/kotlin/no/nav/medlemskap/regler/personer/Personleser.kt
@@ -23,7 +23,7 @@ class Personleser {
     fun enkelNorskPilot() = lesDatagrunnlag("$norsk/norsk_jobb_ikke_maritim_men_pilot.json")
     fun enkelNorskUtenlandskSkip() = lesDatagrunnlag("$norsk/norsk_jobb_maritim_utenlandsk_skip.json")
     fun norskDobbeltStatsborgerskap() = lesDatagrunnlag("$norsk/dobbelt_statsborgerskap.json")
-    fun norskUtenBostedsadresse() = lesDatagrunnlag("$norsk/norsk_bosatt_i_utland.json")
+    fun norskUtenBostedsadresse() = lesDatagrunnlag("$norsk/ingen_bosteds_adresse.json")
     fun postadresseIUtland() = lesDatagrunnlag("$norsk/norsk_postadresse_i_utland.json")
     fun norskMedOpplysningerIMedl() = lesDatagrunnlag("$norsk/norsk_med_opplysninger_i_medl.json")
     fun norskUtenMedlemskapIMedl() = lesDatagrunnlag("$norsk/norsk_uten_medlemskap_i_medl.json")

--- a/src/test/kotlin/no/nav/medlemskap/regler/v1/RegelsettForNorskLovvalgTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/regler/v1/RegelsettForNorskLovvalgTest.kt
@@ -16,8 +16,8 @@ class RegelsettForNorskLovvalgTest {
     }
 
     @Test
-    fun `person ikke bosatt i Norge siste 12 mnd, får uavklart`() {
-        assertSvar("10", Svar.NEI, evaluer(personleser.norskBosattIUtland()), Svar.UAVKLART)
+    fun `person uten bostedsadresse, får uavklart`() {
+        assertSvar("10", Svar.NEI, evaluer(personleser.norskUtenBostedsadresse()), Svar.UAVKLART)
     }
 
     @Test
@@ -27,12 +27,17 @@ class RegelsettForNorskLovvalgTest {
 
     @Test
     fun `norsk person med utenlandsk bostedsadresse, får uavklart`() {
-        assertSvar("10", Svar.NEI, evaluer(personleser.norskBosattIUtland()), Svar.UAVKLART)
+        assertSvar("10", Svar.NEI, evaluer(personleser.norskUtenBostedsadresse()), Svar.UAVKLART)
     }
 
     @Test
     fun `norsk person med utenlandsk postadresse, får uavklart`() {
-        assertSvar("10", Svar.NEI, evaluer(personleser.norskPostadresseIUtland()), Svar.UAVKLART)
+        assertSvar("10", Svar.NEI, evaluer(personleser.postadresseIUtland()), Svar.UAVKLART)
+    }
+
+    @Test
+    fun `norsk person med utenlandsk midlertidig adresse, får uavklart`() {
+        assertSvar("10", Svar.NEI, evaluer(personleser.midlertidigAdresseIUtland()), Svar.UAVKLART)
     }
 
     @Test

--- a/src/test/resources/testpersoner/norske/ingen_bosteds_adresse.json
+++ b/src/test/resources/testpersoner/norske/ingen_bosteds_adresse.json
@@ -13,7 +13,8 @@
       "tom": "2020-01-30"
     } ],
     "personstatuser" : [ ],
-    "bostedsadresser" : [
+    "bostedsadresser" : [],
+    "postadresser" : [
       {
         "adresselinje" : "Stockholm",
         "landkode" : "SWE",
@@ -21,7 +22,6 @@
         "tom" : null
       }
     ],
-    "postadresser" : [ ],
     "midlertidigAdresser" : [ ]
   },
   "medlemskapsunntak" : [ ],

--- a/src/test/resources/testpersoner/norske/midlertidig_adresse_i_utland.json
+++ b/src/test/resources/testpersoner/norske/midlertidig_adresse_i_utland.json
@@ -13,18 +13,32 @@
       "tom": "2020-01-30"
     } ],
     "personstatuser" : [ ],
-    "bostedsadresser" : [],
+    "bostedsadresser" : [
+      {
+        "adresselinje" : "Oslo",
+        "landkode" : "NOR",
+        "fom" : "2018-11-01",
+        "tom" : null
+      }
+    ],
     "postadresser" : [
+      {
+        "adresselinje" : "Oslo",
+        "landkode" : "NOR",
+        "fom" : "2018-11-01",
+        "tom" : null
+      }
+    ],
+    "midlertidigAdresser" : [
       {
         "adresselinje" : "Stockholm",
         "landkode" : "SWE",
         "fom" : "2018-11-01",
         "tom" : null
       }
-    ],
-    "midlertidigAdresser" : [ ]
+    ]
   },
-  "medlemskapsunntak" : [ ],
+  "medlemskap" : [ ],
   "arbeidsforhold" : [ {
     "periode" : {
       "fom" : "2018-01-29",


### PR DESCRIPTION
…. Bostedsadresse maa finnes og det kan ikke vaere noen andresser med utenlandske landekoder. Bostedsadresse - BOAD - vil i folge tps alltid vaere norske saa disse trenger ikke sjekkes. I tilegg lagt inn tester

Regler for adresser: 
 - Det MÅ finnes en bostedsadresse (alle bostedsadresser er norske og trenger ikke landekodesjekk)
-  Det kan finnes kun bostedsadresse
-  Det gjøres sjekk på postadresser og midlertidige adresse, hvis noen av disse har utenlandsk landekode sendes disse til uavklart