### PR TITLE
Setter loggingen av feil i PhaseInterceptorChain til Error,

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -33,6 +33,7 @@
     </logger>
 
     <logger name="org.apache.cxf" level="WARN"/>
+    <logger name="org.apache.cxf.phase.PhaseInterceptorChain" level="ERROR"/>
     <logger name="io.ktor.auth.jwt" level="TRACE"/>
     <logger name="no.nav.medlemskap.common.influx" level="DEBUG"/>
 


### PR DESCRIPTION
…  da vi får en del Warnings fra den i prod som egentlig ikke er reelle feil, de blir håndtert av retry-mekanismen vår, relle feil logges senere i flyten uansett.

Jeg setter pris på om dere vurderer om resonnementet mitt her holder vann!