### PR TITLE
Erstattet expression på alerten som fanger opp 4XX og 5XX feil

### DIFF
--- a/deploy/alerts-preprod.yaml
+++ b/deploy/alerts-preprod.yaml
@@ -26,11 +26,11 @@ spec:
       action: "Sjekk app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
     - alert: Høy andel HTTP serverfeil (5xx responser)
       severity: danger
-      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"5.*"}[3m]))
+      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"5.*"}[3m])) > 1
       for: 3m
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"
     - alert: Høy andel HTTP klientfeil (4xx responser)
       severity: warning
-      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"4.*"}[3m]))
+      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"4.*"}[3m])) > 1
       for: 3m
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"

--- a/deploy/alerts-preprod.yaml
+++ b/deploy/alerts-preprod.yaml
@@ -26,11 +26,11 @@ spec:
       action: "Sjekk app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
     - alert: Høy andel HTTP serverfeil (5xx responser)
       severity: danger
-      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^5\\d\\d", backend=~"medlemskap-oppslag.nais.preprod.local*"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"medlemskap-oppslag.nais.preprod.local*"}[3m])))) > 1
+      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"5.*"}[3m]))
       for: 3m
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"
     - alert: Høy andel HTTP klientfeil (4xx responser)
       severity: warning
-      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^4\\d\\d", backend=~"medlemskap-oppslag.nais.preprod.local*"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"medlemskap-oppslag.nais.preprod.local*"}[3m])))) > 10
+      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"4.*"}[3m]))
       for: 3m
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"

--- a/deploy/alerts-preprod.yaml
+++ b/deploy/alerts-preprod.yaml
@@ -24,13 +24,13 @@ spec:
       expr: selftests_aggregate_result_status{app="medlemskap-oppslag"} > 0
       for: 1m
       action: "Sjekk app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
-    - alert: Høy andel HTTP serverfeil (5xx responser)
+    - alert: HTTP serverfeil (5xx responser)
       severity: danger
-      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"5.*"}[3m])) > 1
+      expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"5.*"}[3m])) > 0
       for: 3m
-      action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"
-    - alert: Høy andel HTTP klientfeil (4xx responser)
+      action: "Sjekk loggene til app {{ $labels.log_app }} i namespace {{ $labels.log_namespace }}, for å se detaljene om 5XX HTTP-feilen(e) som inntraff"
+    - alert: Høy frekvens HTTP klientfeil (4xx responser)
       severity: warning
       expr:  floor(increase(ktor_http_server_requests_seconds_count{app="medlemskap-oppslag",method="POST",route=~"/.authenticate azureAuth.",status=~"4.*"}[3m])) > 1
       for: 3m
-      action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"
+      action: "Sjekk loggene til app {{ $labels.log_app }} i namespace {{ $labels.log_namespace }}, for å se hvorfor det er så mange 4XX HTTP-feil"


### PR DESCRIPTION
Den gamle brukte traefiklogger, den nye bruker micrometer-metrics fra Ktor. Den nye støtter kall både internt i K8s-clusteret og kall utenfra og inn, den gamle gjorde ikke det

Jeg er ingen guru på alerterator, ikke på noen måte, så jeg gikk inn på https://prometheus.nais.preprod.local/rules og sjekket hva som fantes der fra før. Så tilpasset jeg det til vår bruk. Men om jeg egentlig burde brukt en annen spørring, så er jeg åpen for det. Det er andre varianter der også, som disse:
```
 sum(increase(syfovarsel_kafkalytter_stoppet_total[30m])) > 10
```
```
sum by(rule_status) (increase(syfosmregler_rule_hit_status_counter{app=~"syfosmregler",rule_status="INVALID"}[30m])) > 120
```
Men den jeg brukte var den som matchet oss mest, så jeg håper den er grei..