### PR TITLE
Regler for registrerte opplysninger har 3 utfall som følge av medl-ut…

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/common/Metrics.kt
+++ b/src/main/kotlin/no/nav/medlemskap/common/Metrics.kt
@@ -156,6 +156,11 @@ private fun getStillingsprosentIntervall(stillingsprosent: Double): String {
     return "N/A"
 }
 
+fun medlCounter(): Counter = Counter
+        .builder("medl_counter")
+        .description("Registrerer dersom det finnes en periode i medl")
+        .register(Metrics.globalRegistry)
+
 fun apiCounter(): Counter = Counter
         .builder("api_hit_counter")
         .description("Registers a counter for each hit to the api")

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/RegelId.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/RegelId.kt
@@ -34,12 +34,10 @@ enum class RegelId(val identifikator: String, val avklaring: String) {
     REGEL_11_5("11.5", "Er brukers barn folkeregistrert som bosatt i Norge?"),
     REGEL_11_6("11.6", "Har bruker vært i minst 80 % stilling de siste 12 mnd?"),
     REGEL_12("12", "Har bruker vært i minst 25% stilling de siste 12 mnd?"),
-    REGEL_A("A","Finnes det noe på personen i MEDL?"),
-    REGEL_B("B", "Finnes det åpne oppgaver i GOSYS på medlemskapsområdet?"),
     REGEL_OPPLYSNINGER("OPPLYSNINGER", "Finnes det registrerte opplysninger på bruker?"),
-    REGEL_OPPLYSNINGER_MEDL("OPPLYSNINGER-MEDL", "Finnes det registrerte opplysninger i MEDL?"),
-    REGEL_OPPLYSNINGER_JOARK("OPPLYSNINGER-JOARK", "Finnes det dokumenter i JOARK på medlemskapsområdet?"),
-    REGEL_OPPLYSNINGER_GOSYS("OPPLYSNINGER-GOSYS", "Finnes det åpne oppgaver i GOSYS på medlemskapsområdet?"),
+    REGEL_A("OPPLYSNINGER-MEDL", "Finnes det registrerte opplysninger i MEDL?"),
+    REGEL_B("OPPLYSNINGER-GOSYS", "Finnes det åpne oppgaver i GOSYS på medlemskapsområdet?"),
+    REGEL_C("OPPLYSNINGER-JOARK", "Finnes det dokumenter i JOARK på medlemskapsområdet?"),
     REGEL_MEDLEM_KONKLUSJON("LOVME", "Er bruker medlem?")
     ;
 

--- a/src/main/kotlin/no/nav/medlemskap/regler/common/Regler.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/common/Regler.kt
@@ -5,21 +5,21 @@ abstract class Regler {
     abstract fun hentHovedRegel(): Regel
 
     protected fun minstEnAvDisse(vararg regler: Regel): Resultat {
-        val delresultat = regler.map { it.utfør() }
+        val delresultatMap = regler.map { it.regelId to it.utfør() }.toMap()
 
-        return utledResultat(delresultat).copy(
-                delresultat = delresultat
+        return utledResultat(delresultatMap).copy(
+                delresultat = delresultatMap.values.toList()
         )
     }
 
     protected fun sjekkRegel(metode: () -> Regel) = metode.invoke()
 
-    private fun utledResultat(resultater: List<Resultat>): Resultat {
+    private fun utledResultat(resultater: Map<RegelId, Resultat>): Resultat {
+
         return when {
-            resultater.any { it.svar == Svar.UAVKLART } -> uavklart("Minst en av de følgende ble UAVKLART")
-            resultater.any { it.svar == Svar.JA } -> ja("Minst en av de følgende ble JA")
+            resultater[RegelId.REGEL_A]?.svar == Svar.JA && resultater[RegelId.REGEL_B]?.svar == Svar.NEI -> ja()
+            resultater.values.any { it.svar == Svar.JA } -> uavklart()
             else -> nei("Alle de følgende ble NEI")
         }
     }
-
 }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/Hovedregler.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/Hovedregler.kt
@@ -16,25 +16,24 @@ class Hovedregler(datagrunnlag: Datagrunnlag) {
     private val reglerForArbeidsforhold = ReglerForArbeidsforhold.fraDatagrunnlag(datagrunnlag)
 
     fun hentHovedRegel() =
-
             sjekkRegelsett {
-                reglerForRegistrerteOpplysningerIMedl
+                reglerForRegistrerteOpplysninger
+            } hvisJa {
+                sjekkRegelsett {
+                    reglerForRegistrerteOpplysningerIMedl
+                }
             } hvisNei {
                 sjekkRegelsett {
-                    reglerForRegistrerteOpplysninger
-                } hvisJa {
-                    uavklartKonklusjon(ytelse)
+                    reglerForGrunnforordningen
                 } hvisNei {
+                    uavklartKonklusjon(ytelse)
+                } hvisJa {
                     sjekkRegelsett {
-                        reglerForGrunnforordningen
-                    } hvisNei {
-                        uavklartKonklusjon(ytelse)
-                    } hvisJa {
-                        sjekkRegelsett {
-                            reglerForArbeidsforhold
-                        }
+                        reglerForArbeidsforhold
                     }
                 }
+            } hvisUavklart {
+                uavklartKonklusjon(ytelse)
             }
 
     fun kjørHovedregler(): Resultat {

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForMedl.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForMedl.kt
@@ -34,67 +34,58 @@ class ReglerForMedl(
     private val datohjelper = Datohjelper(periode, ytelse)
 
     override fun hentHovedRegel(): Regel =
+
             sjekkRegel {
-                harBrukerMedlOpplysninger
+                erPerioderAvklart
+            } hvisNei {
+                uavklartKonklusjon(ytelse)
             } hvisJa {
                 sjekkRegel {
-                    harBrukerGosysOpplysninger
+                    periodeMedOgUtenMedlemskap
                 } hvisJa {
                     uavklartKonklusjon(ytelse)
                 } hvisNei {
                     sjekkRegel {
-                        erPerioderAvklart
+                        periodeMedMedlemskap
                     } hvisNei {
-                        uavklartKonklusjon(ytelse)
+                        sjekkRegel {
+                            erPeriodeUtenMedlemskapInnenfor12MndPeriode
+                        } hvisNei {
+                            uavklartKonklusjon(ytelse)
+                        } hvisJa {
+                            sjekkRegel {
+                                erArbeidsforholdUendretForBrukerUtenMedlemskap
+                            } hvisJa {
+                                uavklartKonklusjon(ytelse)
+                            } hvisNei {
+                                uavklartKonklusjon(ytelse)
+                            }
+                        }
                     } hvisJa {
                         sjekkRegel {
-                            periodeMedOgUtenMedlemskap
+                            erPeriodeMedMedlemskapInnenfor12MndPeriode
                         } hvisJa {
-                            uavklartKonklusjon(ytelse)
-                        } hvisNei {
                             sjekkRegel {
-                                periodeMedMedlemskap
-                            } hvisNei {
-                                sjekkRegel {
-                                    erPeriodeUtenMedlemskapInnenfor12MndPeriode
-                                } hvisNei {
-                                    uavklartKonklusjon(ytelse)
-                                } hvisJa {
-                                    sjekkRegel {
-                                        erArbeidsforholdUendretForBrukerUtenMedlemskap
-                                    } hvisJa {
-                                        uavklartKonklusjon(ytelse)
-                                    } hvisNei {
-                                        uavklartKonklusjon(ytelse)
-                                    }
-                                }
+                                erArbeidsforholdUendretForBrukerMedMedlemskap
                             } hvisJa {
                                 sjekkRegel {
-                                    erPeriodeMedMedlemskapInnenfor12MndPeriode
+                                    erDekningUavklart
                                 } hvisJa {
+                                    uavklartKonklusjon(ytelse)
+                                } hvisNei {
                                     sjekkRegel {
-                                        erArbeidsforholdUendretForBrukerMedMedlemskap
+                                        harBrukerDekningIMedl
                                     } hvisJa {
-                                        sjekkRegel {
-                                            erDekningUavklart
-                                        } hvisJa {
-                                            uavklartKonklusjon(ytelse)
-                                        } hvisNei {
-                                            sjekkRegel {
-                                                harBrukerDekningIMedl
-                                            } hvisJa {
-                                                jaKonklusjon(ytelse)
-                                            } hvisNei {
-                                                uavklartKonklusjon(ytelse)
-                                            }
-                                        }
+                                        jaKonklusjon(ytelse)
                                     } hvisNei {
                                         uavklartKonklusjon(ytelse)
                                     }
-                                } hvisNei {
-                                    uavklartKonklusjon(ytelse)
                                 }
+                            } hvisNei {
+                                uavklartKonklusjon(ytelse)
                             }
+                        } hvisNei {
+                            uavklartKonklusjon(ytelse)
                         }
                     }
                 }

--- a/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForRegistrerteOpplysninger.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/v1/ReglerForRegistrerteOpplysninger.kt
@@ -1,16 +1,19 @@
 package no.nav.medlemskap.regler.v1
 
+import no.nav.medlemskap.common.medlCounter
 import no.nav.medlemskap.domene.*
 import no.nav.medlemskap.regler.common.*
 import no.nav.medlemskap.regler.common.RegelId.*
 import no.nav.medlemskap.regler.funksjoner.GsakFunksjoner.finnesAapneOppgaver
 import no.nav.medlemskap.regler.funksjoner.JoarkFunksjoner.finnesDokumenterMedTillatteTeamer
+import no.nav.medlemskap.regler.funksjoner.MedlFunksjoner.finnesPersonIMedlForKontrollPeriode
 
 class ReglerForRegistrerteOpplysninger(
         val medlemskap: List<Medlemskap> = emptyList(),
         val oppgaver: List<Oppgave> = emptyList(),
         val dokument: List<Journalpost> = emptyList(),
-        val ytelse: Ytelse
+        val ytelse: Ytelse,
+        val periode: InputPeriode
 ) : Regler() {
 
     override fun hentHovedRegel() =
@@ -25,29 +28,31 @@ class ReglerForRegistrerteOpplysninger(
     )
 
     private val medl = Regel(
-            REGEL_OPPLYSNINGER_MEDL,
+            REGEL_A,
             ytelse = ytelse,
             operasjon = { sjekkPerioderIMedl() }
     )
 
-    private val joark = Regel(
-            regelId = REGEL_OPPLYSNINGER_JOARK,
-            ytelse = ytelse,
-            operasjon = { tellDokumenter() }
-    )
-
     private val gsak = Regel(
-            regelId = REGEL_OPPLYSNINGER_GOSYS,
+            regelId = REGEL_B,
             ytelse = ytelse,
             operasjon = { tellÅpneOppgaver() }
     )
 
+    private val joark = Regel(
+            regelId = REGEL_C,
+            ytelse = ytelse,
+            operasjon = { tellDokumenter() }
+    )
 
-    private fun sjekkPerioderIMedl(): Resultat =
-            when {
-                medlemskap.isNotEmpty() -> ja()
-                else -> nei()
-            }
+    private fun sjekkPerioderIMedl(): Resultat {
+        val kontrollPeriodeForMedl = Datohjelper(periode, ytelse).kontrollPeriodeForMedl()
+        if (medlemskap.isNotEmpty()) medlCounter().increment()
+        return when {
+            medlemskap finnesPersonIMedlForKontrollPeriode kontrollPeriodeForMedl -> ja()
+            else -> nei()
+        }
+    }
 
     private fun tellDokumenter(): Resultat =
             when {
@@ -68,7 +73,8 @@ class ReglerForRegistrerteOpplysninger(
                     medlemskap = datagrunnlag.medlemskap,
                     oppgaver = datagrunnlag.oppgaver,
                     dokument = datagrunnlag.dokument,
-                    ytelse = datagrunnlag.ytelse
+                    ytelse = datagrunnlag.ytelse,
+                    periode = datagrunnlag.periode
             )
         }
     }

--- a/src/test/kotlin/no/nav/medlemskap/regler/v1/RegelsettForMedlTestMidlertidig.kt
+++ b/src/test/kotlin/no/nav/medlemskap/regler/v1/RegelsettForMedlTestMidlertidig.kt
@@ -19,17 +19,17 @@ class RegelsettForMedlTestMidlertidig {
 
     @Test
     fun `amerikansk person med vedtak i medl får uavklart på manuelle vedtak`() {
-        assertSvar(REGEL_A, Svar.JA, evaluer(personleser.amerikanskMedl()), Svar.UAVKLART)
+        assertSvar(REGEL_OPPLYSNINGER, Svar.JA, evaluer(personleser.amerikanskMedl()), Svar.UAVKLART)
     }
 
     @Test
     fun `norsk person med opplysninger i medl`() {
-        assertSvar(REGEL_A, Svar.JA, evaluer(personleser.norskMedOpplysningerIMedl()), Svar.JA)
+        assertSvar(REGEL_OPPLYSNINGER, Svar.JA, evaluer(personleser.norskMedOpplysningerIMedl()), Svar.JA)
     }
 
     @Test
     fun `amerikansk person med vedtak i medl og gosys får uavklart på manuelle vedtak`() {
-        assertSvar(REGEL_B, Svar.JA, evaluer(personleser.amerikanskGosys()), Svar.UAVKLART)
+        assertSvar(REGEL_OPPLYSNINGER, Svar.UAVKLART, evaluer(personleser.amerikanskGosys()), Svar.UAVKLART)
     }
 
 
@@ -75,7 +75,7 @@ class RegelsettForMedlTestMidlertidig {
 
     @Test
     fun `amerikansk person med UAVK (uavklart) statuskode i lovvalg fra medl`() {
-        assertSvar(REGEL_A, Svar.JA, evaluer(personleser.amerikanskUtenMedlemskapLovvalgStatuskodeUavklart()), Svar.UAVKLART)
+        assertSvar(REGEL_OPPLYSNINGER, Svar.JA, evaluer(personleser.amerikanskUtenMedlemskapLovvalgStatuskodeUavklart()), Svar.UAVKLART)
     }
 
     @Test

--- a/src/test/resources/dokumentasjon/features/hovedregler/medlemsopplysninger/medlemskapsopplysninger.feature
+++ b/src/test/resources/dokumentasjon/features/hovedregler/medlemsopplysninger/medlemskapsopplysninger.feature
@@ -3,7 +3,7 @@
 
 Egenskap: Hovedregel "Finnes det registrerte opplysninger på bruker?"
 
-  Scenario: Det finnes opplysninger i MEDL
+  Scenario: Det finnes opplysninger i MEDL (og ikke i Gosys)
     Gitt følgende medlemsunntak fra MEDL
       | Dekning | Fra og med dato | Til og med dato | Er medlem | Lovvalg | Lovvalgsland |
       |         | 01.01.2019      | 28.02.2020      | Nei       | ENDL    | USA          |
@@ -26,9 +26,9 @@ Egenskap: Hovedregel "Finnes det registrerte opplysninger på bruker?"
     Så skal svaret være "<Svar>"
 
     Eksempler:
-      | Tema              | Svar |
-      | MED               | Ja   |
-      | Ikke tillatt tema | Nei  |
+      | Tema              | Svar     |
+      | MED               | UAVKLART |
+      | Ikke tillatt tema | Nei      |
 
   Scenariomal: Det finnes opplysninger i Gosys
     Gitt følgende oppgaver fra Gosys
@@ -42,10 +42,33 @@ Egenskap: Hovedregel "Finnes det registrerte opplysninger på bruker?"
     Så skal svaret være "<Svar>"
 
     Eksempler:
-      | Status      | Tema          | Svar |
-      | AAPNET      | MED           | Ja   |
-      | FERDIGSTILT | MED           | Nei  |
-      | AAPNET      | Ikke godkjent | Nei  |
+      | Status      | Tema          | Svar     |
+      | AAPNET      | MED           | UAVKLART |
+      | FERDIGSTILT | MED           | Nei      |
+      | AAPNET      | Ikke godkjent | Nei      |
+
+
+  Scenariomal: Det finnes opplysninger i Gosys og MEDL
+    Gitt følgende medlemsunntak fra MEDL
+      | Dekning | Fra og med dato | Til og med dato   | Er medlem | Lovvalg | Lovvalgsland |
+      |         | 01.01.2018      | <Til og med dato> | Nei       | ENDL    | USA          |
+    Gitt følgende oppgaver fra Gosys
+      | Aktiv dato | Prioritet | Status   | Tema   |
+      | 15.01.2020 | NORM      | <Status> | <Tema> |
+
+    Når hovedregel med avklaring "Finnes det registrerte opplysninger på bruker?" kjøres med følgende parametre
+      | Fra og med dato | Til og med dato | Har hatt arbeid utenfor Norge |
+      | 01.01.2020      | 30.01.2020      | Nei                           |
+
+    Så skal svaret være "<Svar>"
+
+    Eksempler:
+      | Til og med dato | Status      | Tema          | Svar     |
+      | 28.02.2020      | AAPNET      | MED           | UAVKLART |
+      | 28.02.2020      | FERDIGSTILT | MED           | Ja       |
+      | 30.12.2018      | FERDIGSTILT | MED           | Nei      |
+      | 30.12.2018      | AAPNET      | MED           | UAVKLART |
+      | 28.02.2020      | AAPNET      | Ikke godkjent | Ja       |
 
   Scenario: Det finnes ikke opplysninger på bruker i MEDL, Joark eller Gosys
     Når hovedregel med avklaring "Finnes det registrerte opplysninger på bruker?" kjøres med følgende parametre


### PR DESCRIPTION
…videlsen, med denne endringen skal koden reflektere prosesstegningen bedre. For at man skal regne med at det finnes MEDL-data, må det finnes MEDL-perioder som overlapper med kontrollperiode.

Utfall av regel vises i denne tabellen: https://confluence.adeo.no/pages/viewpage.action?pageId=358576541