### PR TITLE
PDL har deprekert feltet oppholdsadressedato, det er nå trygt å fjern…

### DIFF
--- a/pdl-client/src/main/resources/pdl/hentPerson.graphql
+++ b/pdl-client/src/main/resources/pdl/hentPerson.graphql
@@ -94,7 +94,6 @@ query($ident: ID!, $bostedHistorikk: Boolean!){
       }
     }
     oppholdsadresse(historikk: true) {
-      oppholdsadressedato
       coAdressenavn
       gyldigFraOgMed
       utenlandskAdresse {

--- a/src/main/kotlin/no/nav/medlemskap/services/pdl/PdlMapper.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/pdl/PdlMapper.kt
@@ -73,8 +73,7 @@ object PdlMapper {
     private fun mapOppholdsadresser(oppholdsadresse: HentPerson.Oppholdsadresse, tom: LocalDate?): Adresse {
 
         return Adresse(
-            fom = convertToLocalDate(oppholdsadresse.gyldigFraOgMed)
-                ?: convertToLocalDate(oppholdsadresse.oppholdsadressedato),
+            fom = convertToLocalDate(oppholdsadresse.gyldigFraOgMed),
             tom = convertToLocalDate(oppholdsadresse.folkeregistermetadata?.opphoerstidspunkt),
             landkode = mapLandkodeForOppholdsadresse(oppholdsadresse)
         )


### PR DESCRIPTION
…e det fra koden, da PDL gjør logikken med å bruke oppholdsadressedato i feltet gyldigFraOgMedDato hvis gyldigFraOgMedDato ikke finnes.