### PR TITLE
fix

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/services/pdl/mapper/PdlMapper.kt
+++ b/src/main/kotlin/no/nav/medlemskap/services/pdl/mapper/PdlMapper.kt
@@ -85,6 +85,9 @@ object PdlMapper {
     }
 
     private fun mapLandkode(landkode: String): String {
+        if(landkode.length == 3){
+            return landkode
+        }
         return try {
             CountryCode.getByCode(landkode.toUpperCase()).alpha3
         } catch (e: Exception) {


### PR DESCRIPTION
Dokumentasjonen for UtenlandksAdresse og UtenlandskAdresseIFrittFormat sier dette om hva vi kan forvente på feltet landkode: "Alpha-2 eller alpha-3 (Avklares!)".  Lar dermed det som kommer inn fra PDL som tresifret landekode stå som det er. Bibloteket har noen mangler som feilen nå at den ikke har Kosovo (landkode = XXK)