### PR TITLE
Ryddet opp i bruk av objectmapper i tester. Det er bedre å bruke obje…

### DIFF
--- a/src/test/kotlin/no/nav/medlemskap/clients/ereg/EregMapperTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/clients/ereg/EregMapperTest.kt
@@ -1,31 +1,16 @@
 package no.nav.medlemskap.clients.ereg
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.medlemskap.common.objectMapper
 import no.nav.medlemskap.services.ereg.mapOrganisasjonTilArbeidsgiver
 import org.junit.Assert
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class EregMapperTest {
 
     @Test
     fun mapOrganisasjonTilArbeidsgiver() {
-        val javaTimeModule = JavaTimeModule()
-        val localDateTimeDeserializer = LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))
-        javaTimeModule.addDeserializer(LocalDateTime::class.java, localDateTimeDeserializer)
-
-        val objectMapper: ObjectMapper = ObjectMapper()
-            .registerModules(KotlinModule(), javaTimeModule)
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
         val organisasjon = objectMapper.readValue<Organisasjon>(eregHentOrganisasjonResponse)
 

--- a/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlBarnMapperTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlBarnMapperTest.kt
@@ -1,19 +1,14 @@
 package no.nav.medlemskap.clients.pdl.mapper
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.medlemskap.clients.pdl.generated.HentPerson
+import no.nav.medlemskap.common.objectMapper
 import no.nav.medlemskap.domene.barn.PersonhistorikkBarn
 import no.nav.medlemskap.services.pdl.mapper.PdlMapperBarn
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class PdlBarnMapperTest {
 
@@ -63,15 +58,7 @@ class PdlBarnMapperTest {
     }
 
     fun pdlData(): PersonhistorikkBarn {
-        val localDateTimeDeserializer = LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))
-        javaTimeModule.addDeserializer(LocalDateTime::class.java, localDateTimeDeserializer)
-
-        val objectMapper: ObjectMapper = ObjectMapper()
-            .registerModules(KotlinModule(), javaTimeModule)
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-
         val pdlDataBarn = objectMapper.readValue<HentPerson.Person>(pdlDataJson)
-
         return PdlMapperBarn.mapPersonhistorikkTilBarn("09069534888", pdlDataBarn)
     }
 

--- a/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlEktefelleMapperTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlEktefelleMapperTest.kt
@@ -1,19 +1,14 @@
 package no.nav.medlemskap.clients.pdl.mapper
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.medlemskap.clients.pdl.generated.HentPerson
+import no.nav.medlemskap.common.objectMapper
 import no.nav.medlemskap.domene.ektefelle.PersonhistorikkEktefelle
 import no.nav.medlemskap.services.pdl.mapper.PdlMapperEktefelle
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class PdlEktefelleMapperTest {
 
@@ -58,15 +53,7 @@ class PdlEktefelleMapperTest {
     }
 
     fun pdlData(): PersonhistorikkEktefelle {
-        val localDateTimeDeserializer = LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))
-        javaTimeModule.addDeserializer(LocalDateTime::class.java, localDateTimeDeserializer)
-
-        val objectMapper: ObjectMapper = ObjectMapper()
-            .registerModules(KotlinModule(), javaTimeModule)
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-
         val pdlDataEktefelle = objectMapper.readValue<HentPerson.Person>(pdlDataJson)
-
         return PdlMapperEktefelle.mapPersonhistorikkTilEktefelle("101197512345", pdlDataEktefelle)
     }
 

--- a/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlMapperTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlMapperTest.kt
@@ -1,18 +1,14 @@
 package no.nav.medlemskap.clients.pdl.mapper
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.medlemskap.clients.pdl.generated.HentPerson
-import no.nav.medlemskap.domene.*
+import no.nav.medlemskap.common.objectMapper
+import no.nav.medlemskap.domene.Personhistorikk
 import no.nav.medlemskap.services.pdl.mapper.PdlMapper.mapTilPersonHistorikkTilBruker
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class PdlMapperTest {
 
@@ -84,13 +80,6 @@ class PdlMapperTest {
     }
 
     fun pdlData(): Personhistorikk {
-        val localDateTimeDeserializer = LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))
-        javaTimeModule.addDeserializer(LocalDateTime::class.java, localDateTimeDeserializer)
-
-        val objectMapper: ObjectMapper = ObjectMapper()
-            .registerModules(KotlinModule(), javaTimeModule)
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-
         val pdlData = objectMapper.readValue<HentPerson.Person>(pdlDataJson)
         return mapTilPersonHistorikkTilBruker(pdlData)
     }


### PR DESCRIPTION
…ctmapper som faktisk brukes i source-koden fremfor å lage en egen i testene