### PR TITLE
Beregning av sammenhengende arbeidsforhold tar nå med at dersom til o…

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/domene/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/medlemskap/domene/Arbeidsforhold.kt
@@ -17,6 +17,10 @@ data class Arbeidsforhold(
      */
     override fun compareTo(other: Arbeidsforhold): Int {
 
+        if (this.periode.fom != null && other.periode.fom != null && this.periode.fom != other.periode.fom) {
+            return this.periode.fom.compareTo(other.periode.fom)
+        }
+
         if (this.periode.tom == null && other.periode.tom == null) {
             return this.periode.fom?.compareTo(other.periode.fom)!! // En gyldig periode har alltid minst én dato
         }

--- a/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/ArbeidsforholdFunksjoner.kt
+++ b/src/main/kotlin/no/nav/medlemskap/regler/funksjoner/ArbeidsforholdFunksjoner.kt
@@ -81,7 +81,6 @@ object ArbeidsforholdFunksjoner {
      */
     fun List<Arbeidsforhold>.erSammenhengendeIKontrollPeriode(kontrollPeriode: Kontrollperiode, ytelse: Ytelse): Boolean {
 
-        var forrigeTilDato: LocalDate? = null
         val arbeidsforholdForNorskArbeidsgiver = this.arbeidsforholdForKontrollPeriode(kontrollPeriode)
 
         if (arbeidsforholdForNorskArbeidsgiver.size > 10) {
@@ -105,6 +104,7 @@ object ArbeidsforholdFunksjoner {
             return false
         }
 
+        var forrigeTilDato: LocalDate? = null
         val sortertArbeidsforholdEtterPeriode = arbeidsforholdForNorskArbeidsgiver.sorted()
         for (arbeidsforhold in sortertArbeidsforholdEtterPeriode) { // Sjekker at alle påfølgende arbeidsforhold er sammenhengende
             if (forrigeTilDato != null && !erDatoerSammenhengende(forrigeTilDato, arbeidsforhold.periode.fom)) {
@@ -114,6 +114,7 @@ object ArbeidsforholdFunksjoner {
                 return false
             }
             forrigeTilDato = arbeidsforhold.periode.tom
+            if (forrigeTilDato == null || forrigeTilDato.isAfter(kontrollPeriode.tom)) return true
         }
 
         if (forrigeTilDato != null) {

--- a/src/test/resources/dokumentasjon/features/hovedregler/arbeidsforhold/regel_3_sammenhengende_arbeidsforhold.feature
+++ b/src/test/resources/dokumentasjon/features/hovedregler/arbeidsforhold/regel_3_sammenhengende_arbeidsforhold.feature
@@ -51,11 +51,6 @@ Egenskap: Regel 3: Har bruker sammenhengende arbeidsforhold siste 12 måneder?
 
     Eksempler:
       | Fom        | Tom        | Fom 2      | Tom 2      | Svar | Kommentar                                   |
-      | 01.01.2019 | 15.03.2019 | 01.02.2019 |            | Ja   | Overlappende arbeidsfohold                  |
-      | 01.01.2019 | 15.03.2019 | 16.03.2019 |            | Ja   | Arbeidsforhold som er sammenhengende        |
-      | 01.01.2019 | 15.03.2019 | 17.03.2019 |            | Ja   | Arbeidsforhold med en dags opphold          |
-      | 01.01.2019 |            | 17.03.2019 | 25.04.2019 | Ja   | Første arbeidsforhold uten til dato         |
-      | 01.01.2019 | 15.03.2019 | 18.03.2019 |            | Ja   | Arbeidsforhold med to dager opphold         |
       | 01.01.2019 | 15.03.2019 | 19.03.2019 |            | Nei  | Arbeidsforhold med tre dager opphold        |
       | 01.01.2019 | 15.03.2019 | 17.04.2019 |            | Nei  | Arbeidsforhold som ikke er sammenhengende   |
       | 01.01.2016 | 15.03.2019 | 16.03.2019 | 29.05.2019 | Nei  | Mangler arbeidsforhold i bakkant            |
@@ -63,3 +58,18 @@ Egenskap: Regel 3: Har bruker sammenhengende arbeidsforhold siste 12 måneder?
       | 01.03.2019 | 15.03.2019 | 16.03.2019 |            | Nei  | Mangler arbeidsforhold i forkant            |
 #      | 01.01.2019     |15.03.2019 | 18.03.2019        |                   | Ja   | Arbeidsforhold med to dagers opphold         |
 
+
+  Scenario: Person med mange arbeidsforhold i perioden
+    Gitt følgende arbeidsforhold fra AAReg
+      | Fra og med dato | Til og med dato | Arbeidsgivertype | Arbeidsforholdstype |
+      | 08.04.2019      | 30.09.2019      | Organisasjon     | NORMALT             |
+      | 01.10.2019      | 31.12.2020      | Organisasjon     | NORMALT             |
+      | 01.01.2020      | 31.12.2020      | Organisasjon     | NORMALT             |
+      | 01.01.2020      |                 | Organisasjon     | NORMALT             |
+      | 24.08.2020      | 25.08.2020      | Organisasjon     | NORMALT             |
+
+    Når regel "3" kjøres med følgende parametre
+      | Fra og med dato | Til og med dato | Har hatt arbeid utenfor Norge |
+      | 24.09.2020      | 15.10.2020      | Nei                           |
+
+    Så skal svaret være "Ja"


### PR DESCRIPTION
…g med dato er null kan det svares ja, dersom bruker har en fom-dato før kontrollperiode på et arbeidsforhold, og alle påfølgende arbeidsforhold regnes som sammenhengende.