### PR TITLE
Sjekker at feilmeldinger inneholder konsument

### DIFF
--- a/src/test/kotlin/no/nav/medlemskap/common/LokalWebServer.kt
+++ b/src/test/kotlin/no/nav/medlemskap/common/LokalWebServer.kt
@@ -93,6 +93,15 @@ class LokalWebServer {
                 .extract().asString()
         }
 
+        fun responsUtenStatuskodeSjekk(input: String): String {
+            return given()
+                .body(input)
+                .header(Header("Content-Type", "application/json"))
+                .post("/")
+                .then()
+                .extract().asString()
+        }
+
         fun kontraktMedlemskap(input: String): ValidatableResponse {
             val validationFilter = OpenApiValidationFilter("src/main/resources/lovme.yaml")
 
@@ -121,8 +130,8 @@ class LokalWebServer {
             return response
         }
 
-        fun testResponsKode(input: String, statusKode: Int) {
-            given()
+        fun testResponsKode(input: String, statusKode: Int): String {
+            return given()
                 .body(input)
                 .header(Header("Content-Type", "application/json"))
                 .post("/")

--- a/src/test/kotlin/no/nav/medlemskap/cucumber/steps/RegelSteps.kt
+++ b/src/test/kotlin/no/nav/medlemskap/cucumber/steps/RegelSteps.kt
@@ -271,6 +271,13 @@ class RegelSteps : No {
             LokalWebServer.testResponsKode(input, statusKode)
         }
 
+        Så("Skal feilmeldingen med inputen {string} inneholde konsumenten {string}") { filnavn: String, konsument: String ->
+            val input = RegelSteps::class.java.getResource("/testpersoner/testinput/$filnavn.json").readText()
+            val respons = LokalWebServer.responsUtenStatuskodeSjekk(input)
+
+            assertTrue(respons.contains("for konsument $konsument"))
+        }
+
         Så("skal svaret være {string}") { forventetVerdi: String ->
             val forventetSvar = domenespråkParser.parseSvar(forventetVerdi)
 

--- a/src/test/resources/dokumentasjon/features/medlemskap/TjenesteKallFeilmeldingerTest.feature
+++ b/src/test/resources/dokumentasjon/features/medlemskap/TjenesteKallFeilmeldingerTest.feature
@@ -19,3 +19,16 @@ Egenskap: Tjeneste kall feilmeldinger test
       | "InputMedUgyldigFnr"        |
       | "UgyldigInput"              |
       | "InputMedFomFør2016"        |
+
+  Scenariomal:
+    Når tjenestekall med følgende parametere behandles
+      | Fødselsnummer | Fra og med dato | Til og med dato | Har hatt arbeid utenfor Norge |
+      | 15076500565   | 01.01.2019      | 31.12.2019      | Nei                           |
+
+    Så Skal feilmeldingen med inputen <input> inneholde konsumenten <konsument>
+
+    Eksempler:
+      | input                       | konsument    |
+      | "InputMedTomDatoFørFomDato" | "LOVME"      |
+      | "InputMedUgyldigFnr"        | "LOVME"      |
+      | "InputMedFomFør2016"        | "SYKEPENGER" |

--- a/src/test/resources/testpersoner/testinput/InputMedFomFør2016.json
+++ b/src/test/resources/testpersoner/testinput/InputMedFomFør2016.json
@@ -6,5 +6,6 @@
   },
   "brukerinput": {
     "arbeidUtenforNorge": false
-  }
+  },
+  "ytelse": "SYKEPENGER"
 }


### PR DESCRIPTION
https://trello.com/c/bkIQk7hB/322-gj%C3%B8re-sjekk-p%C3%A5-innholdet-i-feilmeldinger-i-tester

Co-authored-by: ole.christian.kvernberg@nav.no