### PR TITLE
Håndterer UDI-feilsituasjon hvor bruker er død

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/common/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/medlemskap/common/ExceptionHandler.kt
@@ -61,9 +61,13 @@ fun StatusPages.Configuration.exceptionHandler() {
     }
 
     exception<HentPersonstatusFault> { cause ->
-        if (cause.faultInfo.kodeId == 10003) {
-            call.logErrorAndRespond(cause, HttpStatusCode.BadRequest) {
+
+        when (cause.faultInfo.kodeId) {
+            10003 -> call.logErrorAndRespond(cause, HttpStatusCode.BadRequest) {
                 "Person ikke funnet i UDI-tjenesten"
+            }
+            10623 -> call.logErrorAndRespond(cause, HttpStatusCode.BadRequest) {
+                "Person er død og finnes ikke i UDI-tjenesten"
             }
         }
     }


### PR DESCRIPTION
Usikker på om denne skal merges, for vi har jo en sjekk på om bruker er død fra før. Men det kan kanskje hende PDL og UDI ikke er i sync, og at denne sjekken derfor er grei å ha?