### PR TITLE
Sjekk paa adressebeskyttelse

### DIFF
--- a/pdl-client/src/main/resources/pdl/hentPerson.graphql
+++ b/pdl-client/src/main/resources/pdl/hentPerson.graphql
@@ -19,6 +19,9 @@ query($ident: ID!, $bostedHistorikk: Boolean!, $statsborgerskapHistorikk: Boolea
             bekreftelsesdato
             relatertVedSivilstand
         },
+        adressebeskyttelse {
+            gradering
+        },
         bostedsadresse(historikk: true) {
             angittFlyttedato
             gyldigFraOgMed

--- a/src/main/kotlin/no/nav/medlemskap/common/exceptions/GradertAdresseException.kt
+++ b/src/main/kotlin/no/nav/medlemskap/common/exceptions/GradertAdresseException.kt
@@ -1,0 +1,6 @@
+package no.nav.medlemskap.common.exceptions
+
+import no.nav.medlemskap.domene.Ytelse
+import java.lang.Exception
+
+class GradertAdresseException(val system: String, val ytelse: Ytelse) : Exception()

--- a/src/test/kotlin/no/nav/medlemskap/clients/pdl/PdlClientHentPersonTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/clients/pdl/PdlClientHentPersonTest.kt
@@ -133,6 +133,7 @@ class PdlClientHentPersonTest {
                                 }
                             }
                     ],
+                    "adressebeskyttelse": [], 
                     "sivilstand": [
                             {
                             "type": "UGIFT",

--- a/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlClientHentEktefelleTest.kt
+++ b/src/test/kotlin/no/nav/medlemskap/clients/pdl/mapper/PdlClientHentEktefelleTest.kt
@@ -111,6 +111,7 @@ class PdlClientHentEktefelleTest {
                     }
                   }
                 ],
+                "adressebeskyttelse":[],
                 "doedsfall": [],
                 "kontaktadresse": [],
                 "oppholdsadresse": []

--- a/src/test/kotlin/no/nav/medlemskap/cucumber/steps/pdl/PdlMapperSteps.kt
+++ b/src/test/kotlin/no/nav/medlemskap/cucumber/steps/pdl/PdlMapperSteps.kt
@@ -173,6 +173,7 @@ class PdlMapperSteps : No {
         var sivilstander: List<HentPerson.Sivilstand> = emptyList()
         var familierelasjoner: List<HentPerson.ForelderBarnRelasjon> = emptyList()
         var doedsfall: List<HentPerson.Doedsfall> = emptyList()
+        var adressebeskyttelse: List<HentPerson.Adressebeskyttelse> = emptyList()
 
         fun build(): HentPerson.Person {
             return HentPerson.Person(
@@ -182,7 +183,8 @@ class PdlMapperSteps : No {
                 bostedsadresse = bostedsadresser,
                 kontaktadresse = kontaktadresser,
                 oppholdsadresse = oppholdsadresser,
-                doedsfall = doedsfall
+                doedsfall = doedsfall,
+                adressebeskyttelse = adressebeskyttelse
             )
         }
     }


### PR DESCRIPTION
Helles krav til adressebeskyttelse: 

- Hvis bruker har adressebeskyttelse skal det gi valideringsfeil. (Sykepenger har allerede denne sjekken, så dette er en slags dobbelsikring)
- Hvis brukers ektefelle eller barn har adressebeskyttelse skal all data om dem slettes (regnes som at dem ikke finnes). 