### PR TITLE
saf har migrert til team namespaces

### DIFF
--- a/deploy/preprod.yaml
+++ b/deploy/preprod.yaml
@@ -70,7 +70,7 @@ spec:
     - name: AAREG_BASE_URL
       value: https://modapp-q2.adeo.no/aareg-services/api
     - name: SAF_BASE_URL
-      value: http://saf.q1.svc.nais.local/graphql
+      value: http://saf-q1.teamdokumenthandtering/graphql
     - name: OPPGAVE_BASE_URL
       value: https://oppgave-q2.nais.preprod.local
     - name: PDL_BASE_URL

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -63,7 +63,7 @@ spec:
     - name: AAREG_BASE_URL
       value: https://modapp.adeo.no/aareg-services/api
     - name: SAF_BASE_URL
-      value: http://saf.default.svc.nais.local/graphql
+      value: http://saf.teamdokumenthandtering/graphql
     - name: OPPGAVE_BASE_URL
       value: http://oppgave.default.svc.nais.local
     - name: PDL_BASE_URL


### PR DESCRIPTION
Det er ikke tillatt å lage apper i andre namespace enn ditt eget teams namespace lenger på NAIS.
Vi har da opprettet saf apper i test på team namespace teamdokumenthandtering. saf-q0, saf-q1, saf-q4
Ingresser skal da rute mot disse nye appene.
⚠️
Appen deres bruker kubernetes service discovery!
Denne PR endrer kubernetes service discovery url:

Fra http://saf.q1 til http://saf-q1.teamdokumenthandtering på dev-fss.
Fra http://saf.default til til http://saf.teamdokumenthandtering på prod-fss.