### PR TITLE
arbeidsadgangtype til string i logging til securelogs

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/routes/EvalueringRoute.kt
+++ b/src/main/kotlin/no/nav/medlemskap/routes/EvalueringRoute.kt
@@ -223,7 +223,7 @@ private fun loggResponse(fnr: String, response: Response, endpoint: String = "/"
         kv("skipsinfo", response.datagrunnlag.kombinasjonAvSkipsregisterFartsomradeOgSkipstype()),
         kv("response", objectMapper.writeValueAsString(response)),
         kv("gjeldendeOppholdsstatus", response.datagrunnlag.oppholdstillatelse?.gjeldendeOppholdsstatus.toString()),
-        kv("arbeidsadgangtype", response.datagrunnlag.oppholdstillatelse?.arbeidsadgang?.arbeidsadgangType),
+        kv("arbeidsadgangtype", response.datagrunnlag.oppholdstillatelse?.arbeidsadgang?.arbeidsadgangType.toString()),
         kv("endpoint", endpoint)
     )
 


### PR DESCRIPTION
Logging etter tilfeller der arbeidsadgangstype er null er vanskelig pga. måten kibana behandler null verdier på. Håper å gjøre det lettere ved å gjøre det om til string